### PR TITLE
Fix MeshingKit audit issues (animation/noise/hex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ let pointAnimations = [
 ]
 
 let customPattern = AnimationPattern(animations: pointAnimations)
+
+// Apply the pattern to an animated gradient
+MeshingKit.animatedGradient(
+    .size3(.cosmicAurora),
+    showAnimation: $showAnimation,
+    animationSpeed: 1.0,
+    animationPattern: customPattern
+)
 ```
 
 **Animation Parameters:**
@@ -250,7 +258,7 @@ let gradient = MeshingKit.gradient(template: template)
 Create custom gradients by defining your own `GradientTemplate`:
 
 ```swift
-let customTemplate = GradientTemplate(
+let customTemplate = CustomGradientTemplate(
     name: "Custom Gradient",
     size: 3,
     points: [
@@ -266,12 +274,7 @@ let customTemplate = GradientTemplate(
     background: Color.black
 )
 
-let customGradient = MeshGradient(
-    width: customTemplate.size,
-    height: customTemplate.size,
-    points: customTemplate.points,
-    colors: customTemplate.colors
-)
+let customGradient = MeshingKit.gradient(template: customTemplate)
 ```
 
 ## Advanced Animation Examples

--- a/Sources/MeshingKit/AnimatedMeshGradientView.swift
+++ b/Sources/MeshingKit/AnimatedMeshGradientView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import simd
 
 /// Animation constants for mesh gradient animations.
 private enum AnimationConstants {
@@ -246,11 +247,10 @@ public struct AnimatedMeshGradientView: View {
     }
 
     private func clampedToUnitSquare(_ positions: [SIMD2<Float>]) -> [SIMD2<Float>] {
-        positions.map { point in
-            .init(
-                x: min(max(point.x, 0.0), 1.0),
-                y: min(max(point.y, 0.0), 1.0)
-            )
+        let lowerBound = SIMD2<Float>.zero
+        let upperBound = SIMD2<Float>(repeating: 1.0)
+        return positions.map { point in
+            simd_clamp(point, lowerBound, upperBound)
         }
     }
 }

--- a/Sources/MeshingKit/AnimatedMeshGradientView.swift
+++ b/Sources/MeshingKit/AnimatedMeshGradientView.swift
@@ -81,6 +81,11 @@ public struct AnimatedMeshGradientView: View {
     /// When provided, this pattern is applied to `positions` each frame.
     var animationPattern: AnimationPattern?
 
+    /// Whether the gradient should smooth between colors.
+    ///
+    /// Defaults to `true` for softer transitions.
+    var smoothsColors: Bool
+
     /// Creates a new animated mesh gradient view with the specified parameters.
     ///
     /// - Parameters:
@@ -90,6 +95,8 @@ public struct AnimatedMeshGradientView: View {
     ///   - colors: An array of colors associated with the control points.
     ///   - background: The background color of the gradient.
     ///   - animationSpeed: The speed multiplier for the animation (default: 1.0).
+    ///   - animationPattern: Optional custom animation pattern to apply.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     public init(
         gridSize: Int,
         showAnimation: Binding<Bool>,
@@ -97,7 +104,8 @@ public struct AnimatedMeshGradientView: View {
         colors: [Color],
         background: Color,
         animationSpeed: Double = 1.0,
-        animationPattern: AnimationPattern? = nil
+        animationPattern: AnimationPattern? = nil,
+        smoothsColors: Bool = true
     ) {
         self.gridSize = gridSize
         self._showAnimation = showAnimation
@@ -106,6 +114,7 @@ public struct AnimatedMeshGradientView: View {
         self.background = background
         self.animationSpeed = animationSpeed
         self.animationPattern = animationPattern
+        self.smoothsColors = smoothsColors
     }
 
     /// The body of the view, displaying an animated mesh gradient.
@@ -119,7 +128,7 @@ public struct AnimatedMeshGradientView: View {
                 locations: .points(animatedPositions(for: phase.date)),
                 colors: .colors(colors),
                 background: background,
-                smoothsColors: true
+                smoothsColors: smoothsColors
             )
             .ignoresSafeArea()
         }

--- a/Sources/MeshingKit/Color+Hex.swift
+++ b/Sources/MeshingKit/Color+Hex.swift
@@ -24,19 +24,19 @@ extension Color {
         let hex = hex.trimmingCharacters(
             in: CharacterSet.alphanumerics.inverted)
         var int: UInt64 = 0
-        Scanner(string: hex).scanHexInt64(&int)
+        let scanned = Scanner(string: hex).scanHexInt64(&int)
         let a: UInt64
         let r: UInt64
         let g: UInt64
         let b: UInt64
-        switch hex.count {
-        case 3:  // RGB (12-bit)
+        switch (scanned, hex.count) {
+        case (true, 3):  // RGB (12-bit)
             (a, r, g, b) = (
                 255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17
             )
-        case 6:  // RGB (24-bit)
+        case (true, 6):  // RGB (24-bit)
             (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8:  // ARGB (32-bit)
+        case (true, 8):  // ARGB (32-bit)
             (a, r, g, b) = (
                 int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF
             )

--- a/Sources/MeshingKit/GradientTemplate.swift
+++ b/Sources/MeshingKit/GradientTemplate.swift
@@ -16,7 +16,9 @@ public protocol GradientTemplate: Sendable {
     /// The name of the gradient template.
     var name: String { get }
 
-    /// The size of the gradient, representing both width and height in pixels.
+    /// The grid size of the gradient.
+    ///
+    /// For example, a size of `3` represents a 3×3 grid (9 control points/colors).
     var size: Int { get }
 
     /// An array of 2D points that define the control points of the gradient.
@@ -43,7 +45,9 @@ public struct CustomGradientTemplate: GradientTemplate {
     /// The name of the gradient template.
     public let name: String
 
-    /// The size of the gradient, representing both width and height in pixels.
+    /// The grid size of the gradient.
+    ///
+    /// For example, a size of `4` represents a 4×4 grid (16 control points/colors).
     public let size: Int
 
     /// An array of 2D points that define the control points of the gradient.
@@ -67,7 +71,7 @@ public struct CustomGradientTemplate: GradientTemplate {
     ///
     /// - Parameters:
     ///   - name: A string that identifies the gradient template.
-    ///   - size: The dimensions of the gradient in pixels (width and height are equal).
+    ///   - size: The grid size (width and height are equal).
     ///   - points: An array of `SIMD2<Float>` values representing the control points.
     ///   - colors: An array of `Color` values corresponding to each control point.
     ///   - background: The base color of the gradient.

--- a/Sources/MeshingKit/GradientTemplate.swift
+++ b/Sources/MeshingKit/GradientTemplate.swift
@@ -67,6 +67,86 @@ public struct CustomGradientTemplate: GradientTemplate {
     /// This color is used as the base color for areas not directly affected by the control points.
     public let background: Color
 
+    /// Validation issues for custom gradient templates.
+    public enum ValidationError: Error, Equatable {
+        case invalidSize(Int)
+        case pointsCount(expected: Int, actual: Int)
+        case colorsCount(expected: Int, actual: Int)
+        case pointOutOfRange(index: Int, x: Float, y: Float)
+    }
+
+    /// A collection of validation errors for a custom gradient template.
+    public struct ValidationErrors: Error, Equatable {
+        public let errors: [ValidationError]
+
+        public init(errors: [ValidationError]) {
+            self.errors = errors
+        }
+    }
+
+    /// Validates the provided template data without triggering a precondition.
+    ///
+    /// - Returns: An array of validation errors. Empty means the data is valid.
+    public static func validate(
+        size: Int,
+        points: [SIMD2<Float>],
+        colors: [Color]
+    ) -> [ValidationError] {
+        var errors: [ValidationError] = []
+
+        guard size > 0 else {
+            errors.append(.invalidSize(size))
+            return errors
+        }
+
+        let expectedCount = size * size
+
+        if points.count != expectedCount {
+            errors.append(.pointsCount(expected: expectedCount, actual: points.count))
+        }
+
+        if colors.count != expectedCount {
+            errors.append(.colorsCount(expected: expectedCount, actual: colors.count))
+        }
+
+        for (index, point) in points.enumerated() {
+            if point.x < 0.0 || point.x > 1.0 || point.y < 0.0 || point.y > 1.0 {
+                errors.append(.pointOutOfRange(index: index, x: point.x, y: point.y))
+            }
+        }
+
+        return errors
+    }
+
+    /// Validates the current template data without triggering a precondition.
+    ///
+    /// - Returns: An array of validation errors. Empty means the data is valid.
+    public func validate() -> [ValidationError] {
+        Self.validate(size: size, points: points, colors: colors)
+    }
+
+    /// Creates a new custom gradient template with validation.
+    ///
+    /// - Throws: `ValidationErrors` if validation fails.
+    public init(
+        validating name: String,
+        size: Int,
+        points: [SIMD2<Float>],
+        colors: [Color],
+        background: Color
+    ) throws {
+        let errors = Self.validate(size: size, points: points, colors: colors)
+        guard errors.isEmpty else {
+            throw ValidationErrors(errors: errors)
+        }
+
+        self.name = name
+        self.size = size
+        self.points = points
+        self.colors = colors
+        self.background = background
+    }
+
     /// Creates a new custom gradient template with the specified parameters.
     ///
     /// - Parameters:

--- a/Sources/MeshingKit/MeshingKit.swift
+++ b/Sources/MeshingKit/MeshingKit.swift
@@ -191,22 +191,17 @@ public struct MeshingKit: Sendable {
         animationSpeed: Double = 1.0,
         animationPattern: AnimationPattern? = nil
     ) -> some View {
-        switch template {
-        case .size2(let template):
-            return animatedGradient(
-                template, showAnimation: showAnimation,
-                animationSpeed: animationSpeed,
-                animationPattern: animationPattern)
-        case .size3(let template):
-            return animatedGradient(
-                template, showAnimation: showAnimation,
-                animationSpeed: animationSpeed,
-                animationPattern: animationPattern)
-        case .size4(let template):
-            return animatedGradient(
-                template, showAnimation: showAnimation,
-                animationSpeed: animationSpeed,
-                animationPattern: animationPattern)
+        let baseTemplate: any GradientTemplate = switch template {
+        case .size2(let specificTemplate): specificTemplate
+        case .size3(let specificTemplate): specificTemplate
+        case .size4(let specificTemplate): specificTemplate
         }
+
+        return animatedGradient(
+            baseTemplate,
+            showAnimation: showAnimation,
+            animationSpeed: animationSpeed,
+            animationPattern: animationPattern
+        )
     }
 }

--- a/Sources/MeshingKit/MeshingKit.swift
+++ b/Sources/MeshingKit/MeshingKit.swift
@@ -22,17 +22,22 @@ public struct MeshingKit: Sendable {
     /// This function takes a `GradientTemplateSize3` and converts it into a `MeshGradient`,
     /// using the template's size, points, and colors.
     ///
-    /// - Parameter template: A `GradientTemplateSize3` containing the gradient's specifications.
+    /// - Parameters:
+    ///   - template: A `GradientTemplateSize3` containing the gradient's specifications.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A `MeshGradient` instance created from the provided template.
     ///
     /// Example:
     /// ```swift
     /// let gradient = MeshingKit.gradientSize3(template: .auroraBorealis)
     /// ```
-    @MainActor public static func gradientSize3(template: GradientTemplateSize3)
+    @MainActor public static func gradientSize3(
+        template: GradientTemplateSize3,
+        smoothsColors: Bool = true
+    )
         -> MeshGradient
     {
-        gradient(template: template)
+        gradient(template: template, smoothsColors: smoothsColors)
     }
 
     /// Creates a `MeshGradient` from a given `GradientTemplateSize2`.
@@ -40,17 +45,22 @@ public struct MeshingKit: Sendable {
     /// This function takes a `GradientTemplateSize2` and converts it into a `MeshGradient`,
     /// using the template's size, points, and colors.
     ///
-    /// - Parameter template: A `GradientTemplateSize2` containing the gradient's specifications.
+    /// - Parameters:
+    ///   - template: A `GradientTemplateSize2` containing the gradient's specifications.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A `MeshGradient` instance created from the provided template.
     ///
     /// Example:
     /// ```swift
     /// let gradient = MeshingKit.gradientSize2(template: .mysticTwilight)
     /// ```
-    @MainActor public static func gradientSize2(template: GradientTemplateSize2)
+    @MainActor public static func gradientSize2(
+        template: GradientTemplateSize2,
+        smoothsColors: Bool = true
+    )
         -> MeshGradient
     {
-        gradient(template: template)
+        gradient(template: template, smoothsColors: smoothsColors)
     }
 
     /// Creates a `MeshGradient` from a given `GradientTemplateSize4`.
@@ -58,17 +68,22 @@ public struct MeshingKit: Sendable {
     /// This function takes a `GradientTemplateSize4` and converts it into a `MeshGradient`,
     /// using the template's size, points, and colors.
     ///
-    /// - Parameter template: A `GradientTemplateSize4` containing the gradient's specifications.
+    /// - Parameters:
+    ///   - template: A `GradientTemplateSize4` containing the gradient's specifications.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A `MeshGradient` instance created from the provided template.
     ///
     /// Example:
     /// ```swift
     /// let gradient = MeshingKit.gradientSize4(template: .cosmicNebula)
     /// ```
-    @MainActor public static func gradientSize4(template: GradientTemplateSize4)
+    @MainActor public static func gradientSize4(
+        template: GradientTemplateSize4,
+        smoothsColors: Bool = true
+    )
         -> MeshGradient
     {
-        gradient(template: template)
+        gradient(template: template, smoothsColors: smoothsColors)
     }
 
     /// Creates a `MeshGradient` from a given `GradientTemplate`.
@@ -76,7 +91,9 @@ public struct MeshingKit: Sendable {
     /// This function takes any `GradientTemplate` and converts it into a `MeshGradient`,
     /// using the template's size, points, and colors.
     ///
-    /// - Parameter template: A `GradientTemplate` containing the gradient's specifications.
+    /// - Parameters:
+    ///   - template: A `GradientTemplate` containing the gradient's specifications.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A `MeshGradient` instance created from the provided template.
     ///
     /// Example:
@@ -89,7 +106,10 @@ public struct MeshingKit: Sendable {
     ///                                              points: [...], colors: [...], background: .black)
     /// let gradient = MeshingKit.gradient(template: customTemplate)
     /// ```
-    @MainActor public static func gradient(template: GradientTemplate)
+    @MainActor public static func gradient(
+        template: GradientTemplate,
+        smoothsColors: Bool = true
+    )
         -> MeshGradient
     {
         MeshGradient(
@@ -98,30 +118,34 @@ public struct MeshingKit: Sendable {
             locations: .points(template.points),
             colors: .colors(template.colors),
             background: template.background,
-            smoothsColors: true
+            smoothsColors: smoothsColors
         )
     }
 
     /// Creates a `MeshGradient` from a predefined template.
     ///
-    /// - Parameter template: The predefined template to use.
+    /// - Parameters:
+    ///   - template: The predefined template to use.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A `MeshGradient` instance created from the provided template.
     ///
     /// Example:
     /// ```swift
     /// let gradient = MeshingKit.gradient(template: .size3(.auroraBorealis))
     /// ```
-    @MainActor public static func gradient(template: PredefinedTemplate)
+    @MainActor public static func gradient(
+        template: PredefinedTemplate,
+        smoothsColors: Bool = true
+    )
         -> MeshGradient
     {
-        switch template {
-        case .size2(let template):
-            return gradient(template: template)
-        case .size3(let template):
-            return gradient(template: template)
-        case .size4(let template):
-            return gradient(template: template)
+        let baseTemplate: any GradientTemplate = switch template {
+        case .size2(let specificTemplate): specificTemplate
+        case .size3(let specificTemplate): specificTemplate
+        case .size4(let specificTemplate): specificTemplate
         }
+
+        return gradient(template: baseTemplate, smoothsColors: smoothsColors)
     }
 
     /// Creates an animated `MeshGradient` view from any gradient template.
@@ -130,6 +154,8 @@ public struct MeshingKit: Sendable {
     ///   - template: A gradient template to use.
     ///   - showAnimation: A binding to control the animation's play/pause state.
     ///   - animationSpeed: Controls the speed of the animation (default: 1.0).
+    ///   - animationPattern: Optional custom animation pattern to apply.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A view containing the animated `MeshGradient`.
     ///
     /// Example:
@@ -150,7 +176,8 @@ public struct MeshingKit: Sendable {
         _ template: any GradientTemplate,
         showAnimation: Binding<Bool>,
         animationSpeed: Double = 1.0,
-        animationPattern: AnimationPattern? = nil
+        animationPattern: AnimationPattern? = nil,
+        smoothsColors: Bool = true
     ) -> some View {
         AnimatedMeshGradientView(
             gridSize: template.size,
@@ -159,7 +186,8 @@ public struct MeshingKit: Sendable {
             colors: template.colors,
             background: template.background,
             animationSpeed: animationSpeed,
-            animationPattern: animationPattern
+            animationPattern: animationPattern,
+            smoothsColors: smoothsColors
         )
     }
 
@@ -169,6 +197,8 @@ public struct MeshingKit: Sendable {
     ///   - template: A predefined template to use.
     ///   - showAnimation: A binding to control the animation's play/pause state.
     ///   - animationSpeed: Controls the speed of the animation (default: 1.0).
+    ///   - animationPattern: Optional custom animation pattern to apply.
+    ///   - smoothsColors: Whether the gradient should smooth between colors (default: `true`).
     /// - Returns: A view containing the animated `MeshGradient`.
     ///
     /// Example:
@@ -189,7 +219,8 @@ public struct MeshingKit: Sendable {
         _ template: PredefinedTemplate,
         showAnimation: Binding<Bool>,
         animationSpeed: Double = 1.0,
-        animationPattern: AnimationPattern? = nil
+        animationPattern: AnimationPattern? = nil,
+        smoothsColors: Bool = true
     ) -> some View {
         let baseTemplate: any GradientTemplate = switch template {
         case .size2(let specificTemplate): specificTemplate
@@ -201,7 +232,8 @@ public struct MeshingKit: Sendable {
             baseTemplate,
             showAnimation: showAnimation,
             animationSpeed: animationSpeed,
-            animationPattern: animationPattern
+            animationPattern: animationPattern,
+            smoothsColors: smoothsColors
         )
     }
 }

--- a/Sources/MeshingKit/MeshingKit.swift
+++ b/Sources/MeshingKit/MeshingKit.swift
@@ -93,8 +93,13 @@ public struct MeshingKit: Sendable {
         -> MeshGradient
     {
         MeshGradient(
-            width: template.size, height: template.size,
-            points: template.points, colors: template.colors)
+            width: template.size,
+            height: template.size,
+            locations: .points(template.points),
+            colors: .colors(template.colors),
+            background: template.background,
+            smoothsColors: true
+        )
     }
 
     /// Creates a `MeshGradient` from a predefined template.
@@ -144,14 +149,17 @@ public struct MeshingKit: Sendable {
     @MainActor public static func animatedGradient(
         _ template: any GradientTemplate,
         showAnimation: Binding<Bool>,
-        animationSpeed: Double = 1.0
+        animationSpeed: Double = 1.0,
+        animationPattern: AnimationPattern? = nil
     ) -> some View {
         AnimatedMeshGradientView(
             gridSize: template.size,
             showAnimation: showAnimation,
             positions: template.points,
             colors: template.colors,
-            background: template.background
+            background: template.background,
+            animationSpeed: animationSpeed,
+            animationPattern: animationPattern
         )
     }
 
@@ -180,21 +188,25 @@ public struct MeshingKit: Sendable {
     @MainActor public static func animatedGradient(
         _ template: PredefinedTemplate,
         showAnimation: Binding<Bool>,
-        animationSpeed: Double = 1.0
+        animationSpeed: Double = 1.0,
+        animationPattern: AnimationPattern? = nil
     ) -> some View {
         switch template {
         case .size2(let template):
             return animatedGradient(
                 template, showAnimation: showAnimation,
-                animationSpeed: animationSpeed)
+                animationSpeed: animationSpeed,
+                animationPattern: animationPattern)
         case .size3(let template):
             return animatedGradient(
                 template, showAnimation: showAnimation,
-                animationSpeed: animationSpeed)
+                animationSpeed: animationSpeed,
+                animationPattern: animationPattern)
         case .size4(let template):
             return animatedGradient(
                 template, showAnimation: showAnimation,
-                animationSpeed: animationSpeed)
+                animationSpeed: animationSpeed,
+                animationPattern: animationPattern)
         }
     }
 }

--- a/Sources/MeshingKit/ParameterizedNoiseView.swift
+++ b/Sources/MeshingKit/ParameterizedNoiseView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A view that applies a parameterized noise effect to a MeshGradient.
 ///
-/// Use `ParameterizedNoiseView` to add a customizable noise effect to a `MeshGradient` view.
+/// Use `ParameterizedNoiseView` to add a customizable noise effect to a view (commonly a `MeshGradient`).
 /// The noise effect is controlled by three parameters: intensity, frequency, and opacity.
 ///
 /// Example usage:
@@ -13,10 +13,10 @@ import SwiftUI
 /// ```
 ///
 /// - Important: This view requires iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, or visionOS 2.0 and later.
-public struct ParameterizedNoiseView: View {
+public struct ParameterizedNoiseView<Content: View>: View {
 
-    /// The MeshGradient to which the noise effect is applied.
-    let gradient: MeshGradient
+    /// The view to which the noise effect is applied.
+    let content: Content
 
     /// The intensity of the noise effect.
     ///
@@ -40,25 +40,29 @@ public struct ParameterizedNoiseView: View {
     ///   - intensity: A binding to the intensity of the noise effect.
     ///   - frequency: A binding to the frequency of the noise pattern.
     ///   - opacity: A binding to the opacity of the noise effect.
-    ///   - content: A closure that returns the MeshGradient to which the noise effect will be applied.
+    ///   - content: A closure that returns the view to which the noise effect will be applied.
     public init(
         intensity: Binding<Float>, frequency: Binding<Float>,
-        opacity: Binding<Float>, @ViewBuilder content: () -> MeshGradient
+        opacity: Binding<Float>, @ViewBuilder content: () -> Content
     ) {
         self._intensity = intensity
         self._frequency = frequency
         self._opacity = opacity
-        self.gradient = content()
+        self.content = content()
     }
 
     /// The body of the view, applying the noise effect to the MeshGradient.
     public var body: some View {
-        gradient
+        let clampedIntensity = min(max(intensity, 0), 1)
+        let clampedFrequency = max(frequency, 0)
+        let clampedOpacity = min(max(opacity, 0), 1)
+
+        content
             .colorEffect(
                 ShaderLibrary.parameterizedNoise(
-                    .float(intensity),
-                    .float(frequency),
-                    .float(opacity)
+                    .float(clampedIntensity),
+                    .float(clampedFrequency),
+                    .float(clampedOpacity)
                 )
             )
     }

--- a/Tests/MeshingKitTests/MeshingKitTests.swift
+++ b/Tests/MeshingKitTests/MeshingKitTests.swift
@@ -203,11 +203,11 @@ struct MeshingKitTests {
                 colors: colors,
                 background: .black
             )
-            #expect(false, "Expected validating initializer to throw")
+            #expect(Bool(false), "Expected validating initializer to throw")
         } catch let error as CustomGradientTemplate.ValidationErrors {
             #expect(!error.errors.isEmpty)
         } catch {
-            #expect(false, "Unexpected error type: \(error)")
+            #expect(Bool(false), "Unexpected error type: \(error)")
         }
     }
 


### PR DESCRIPTION
This PR applies the audit fixes:

- Use template `background` + `smoothsColors` when creating `MeshGradient`.
- Wire `animationSpeed` through `MeshingKit.animatedGradient` and add optional `AnimationPattern`.
- Guard `AnimatedMeshGradientView` against out-of-bounds indexing and clamp pattern-driven points to [0, 1].
- Make `ParameterizedNoiseView` generic over any `View` and clamp parameters.
- Make `Color(hex:)` default to white on invalid hex scan.
- Update README examples accordingly.

Tests: `swift test`.