### PR TITLE
Add template metadata and search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MeshingKit is a Swift library for creating mesh gradients in SwiftUI. It provides 68 predefined gradient templates (2x2, 3x3, 4x4 grids), animated gradients, and Metal shader-based noise effects.
+
+## Build Commands
+
+```bash
+# Swift Package Manager build
+swift build
+
+# Build for a specific target
+swift build --target MeshingKit
+
+# Xcode build for iOS Simulator
+xcodebuild clean build -project Sources/Meshin/Meshin.xcodeproj -scheme Meshin -destination "platform=iOS Simulator,name=iPhone 17 Pro"
+```
+
+## Test Commands
+
+```bash
+swift test --verbose
+swift test --enable-code-coverage
+```
+
+## Lint
+
+```bash
+swiftlint --strict
+```
+
+A pre-commit hook runs SwiftLint on staged files. Setup with `scripts/setup-hooks.sh`.
+
+## Architecture
+
+**Main API:** `MeshingKit.swift` exposes static `gradient()` and `animatedGradient()` methods.
+
+**Template System:**
+- `GradientTemplate` protocol defines the mesh gradient structure
+- `PredefinedTemplate` enum wraps all 68 templates with metadata and search support
+- Templates are organized by grid size: `GradientTemplateSize2`, `GradientTemplateSize3`, `GradientTemplateSize4`
+
+**Key Views:**
+- `AnimatedMeshGradientView` - SwiftUI view for animated gradients
+- `ParameterizedNoiseView` - Metal shader noise effect
+
+**Search:** `PredefinedTemplate.find(by: token)` uses NaturalLanguage for lemmatization and camelCase splitting.
+
+## Important Conventions
+
+- All public types conform to `Sendable` for concurrency safety
+- Tests use Swift Testing framework with `#expect` macro
+- Template files are excluded from SwiftLint (`.swiftlint.yml`) due to size
+- CI runs on Codemagic (see `codemagic.yaml`)
+
+## Source Structure
+
+```
+Sources/MeshingKit/     # Main library
+Sources/Meshin/         # Demo app
+Tests/MeshingKitTests/  # Swift Testing suite
+scripts/                # Git hooks and setup
+```

--- a/README.md
+++ b/README.md
@@ -223,6 +223,22 @@ let size3Count = GradientTemplateSize3.allCases.count
 let size4Count = GradientTemplateSize4.allCases.count
 ```
 
+### Searching Templates
+
+You can search across template names, tags, and moods using `PredefinedTemplate.find(by:)`:
+
+```swift
+// Find templates by keyword
+let matches = PredefinedTemplate.find(by: "aurora")
+
+// Inspect metadata
+if let first = matches.first {
+    print(first.tags)
+    print(first.moods)
+    print(first.palette)
+}
+```
+
 ### Popular Template Examples
 
 **2x2 Grid Templates (35 total):**

--- a/Sources/MeshingKit/PredefinedTemplate.swift
+++ b/Sources/MeshingKit/PredefinedTemplate.swift
@@ -6,9 +6,13 @@
 //
 
 import Foundation
+import SwiftUI
+#if canImport(NaturalLanguage)
+import NaturalLanguage
+#endif
 
 /// A type representing predefined gradient templates of different sizes.
-public enum PredefinedTemplate: Identifiable, CaseIterable {
+public enum PredefinedTemplate: Identifiable, CaseIterable, Equatable {
     case size2(GradientTemplateSize2)
     case size3(GradientTemplateSize3)
     case size4(GradientTemplateSize4)
@@ -33,4 +37,239 @@ public enum PredefinedTemplate: Identifiable, CaseIterable {
         case .size4(let template): return "size4_\(template.rawValue)"
         }
     }
+}
+
+/// Describes the mood of a gradient template for browsing and search.
+public enum TemplateMood: String, CaseIterable, Sendable {
+    case aquatic
+    case bright
+    case cool
+    case cosmic
+    case dark
+    case earthy
+    case fiery
+    case vibrant
+    case warm
+}
+
+/// Metadata for a predefined template.
+public struct TemplateMetadata: Sendable {
+    public let name: String
+    public let tags: [String]
+    public let moods: [TemplateMood]
+    public let palette: [Color]
+    public let background: Color
+
+    public init(
+        name: String,
+        tags: [String],
+        moods: [TemplateMood],
+        palette: [Color],
+        background: Color
+    ) {
+        self.name = name
+        self.tags = tags
+        self.moods = moods
+        self.palette = palette
+        self.background = background
+    }
+}
+
+public extension PredefinedTemplate {
+    /// The underlying template for this predefined case.
+    var template: any GradientTemplate {
+        switch self {
+        case .size2(let specificTemplate): return specificTemplate
+        case .size3(let specificTemplate): return specificTemplate
+        case .size4(let specificTemplate): return specificTemplate
+        }
+    }
+
+    /// A user-facing name for the template.
+    var name: String {
+        template.name
+    }
+
+    /// The palette colors for the template.
+    var palette: [Color] {
+        template.colors
+    }
+
+    /// The background color for the template.
+    var background: Color {
+        template.background
+    }
+
+    /// Tags derived from the template name and mood.
+    var tags: [String] {
+        let nameTokens = Self.normalizedTokens(from: rawName)
+        let moods = Self.moods(for: nameTokens)
+        let moodTokens = moods.map(\.rawValue)
+        return Self.uniqueTokens(nameTokens + moodTokens)
+    }
+
+    /// Moods derived from the template name.
+    var moods: [TemplateMood] {
+        Self.moods(for: Self.normalizedTokens(from: rawName))
+    }
+
+    /// Combined metadata for the template.
+    var metadata: TemplateMetadata {
+        TemplateMetadata(
+            name: name,
+            tags: tags,
+            moods: moods,
+            palette: palette,
+            background: background
+        )
+    }
+
+    /// Finds templates that best match the query.
+    ///
+    /// - Parameters:
+    ///   - query: Search terms (name, tags, or mood).
+    ///   - limit: Optional limit for the number of results.
+    /// - Returns: Templates ordered by best match.
+    static func find(by query: String, limit: Int? = nil) -> [PredefinedTemplate] {
+        let queryTokens = normalizedTokens(from: query)
+        guard !queryTokens.isEmpty else {
+            return allCases
+        }
+
+        let results = allCases.compactMap { template -> (score: Int, template: PredefinedTemplate)? in
+            let tokens = template.searchTokens
+            let score = matchScore(for: queryTokens, in: tokens)
+            return score > 0 ? (score, template) : nil
+        }
+        .sorted { lhs, rhs in
+            if lhs.score == rhs.score {
+                return lhs.template.id < rhs.template.id
+            }
+            return lhs.score > rhs.score
+        }
+        .map { $0.template }
+
+        if let limit {
+            return Array(results.prefix(limit))
+        }
+        return results
+    }
+}
+
+private extension PredefinedTemplate {
+    var rawName: String {
+        switch self {
+        case .size2(let specificTemplate): return specificTemplate.rawValue
+        case .size3(let specificTemplate): return specificTemplate.rawValue
+        case .size4(let specificTemplate): return specificTemplate.rawValue
+        }
+    }
+
+    var searchTokens: [String] {
+        tags
+    }
+
+    static func moods(for tokens: [String]) -> [TemplateMood] {
+        var matched: [TemplateMood] = []
+
+        for (mood, keywords) in moodKeywords where tokens.contains(where: keywords.contains) {
+            matched.append(mood)
+        }
+
+        return matched
+    }
+
+    static func matchScore(for queryTokens: [String], in tokens: [String]) -> Int {
+        var score = 0
+
+        for query in queryTokens {
+            if tokens.contains(query) {
+                score += 3
+                continue
+            }
+
+            if tokens.contains(where: { $0.hasPrefix(query) }) {
+                score += 2
+                continue
+            }
+
+            if tokens.contains(where: { $0.contains(query) }) {
+                score += 1
+            }
+        }
+
+        return score
+    }
+
+    static func normalizedTokens(from string: String) -> [String] {
+        let rawTokens = basicTokens(from: string)
+#if canImport(NaturalLanguage)
+        return rawTokens.map { lemmatize($0) }
+#else
+        return rawTokens
+#endif
+    }
+
+    static func basicTokens(from string: String) -> [String] {
+        let components = string
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+
+        let splitTokens = components.flatMap { splitCamelCase($0) }
+        return splitTokens.map { $0.lowercased() }
+    }
+
+    static func splitCamelCase(_ string: String) -> [String] {
+        var tokens: [String] = []
+        var current = ""
+
+        for character in string {
+            if character.isUppercase, !current.isEmpty {
+                tokens.append(current)
+                current = ""
+            }
+            current.append(character)
+        }
+
+        if !current.isEmpty {
+            tokens.append(current)
+        }
+
+        return tokens
+    }
+
+    static func uniqueTokens(_ tokens: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+
+        for token in tokens where seen.insert(token).inserted {
+            result.append(token)
+        }
+
+        return result
+    }
+
+    static let moodKeywords: [TemplateMood: Set<String>] = [
+        .aquatic: ["ocean", "sea", "lagoon", "breeze", "mist"],
+        .bright: ["sunrise", "morning", "glow", "dawn"],
+        .cool: ["arctic", "frost", "winter", "ice", "mint"],
+        .cosmic: ["cosmic", "aurora", "nebula", "galaxy", "starry"],
+        .dark: ["midnight", "night", "shadow"],
+        .earthy: ["forest", "meadow", "jungle", "dunes", "desert"],
+        .fiery: ["ember", "lava", "volcanic", "fire", "blaze"],
+        .vibrant: ["neon", "electric", "citrus"],
+        .warm: ["sunset", "golden", "autumn", "crimson"]
+    ]
+
+#if canImport(NaturalLanguage)
+    static func lemmatize(_ token: String) -> String {
+        let tagger = NLTagger(tagSchemes: [.lemma])
+        tagger.string = token
+        let (tag, _) = tagger.tag(at: token.startIndex, unit: .word, scheme: .lemma)
+        if let lemma = tag?.rawValue, !lemma.isEmpty, lemma != token {
+            return lemma
+        }
+        return token.lowercased()
+    }
+#endif
 }

--- a/Sources/MeshingKit/PredefinedTemplate.swift
+++ b/Sources/MeshingKit/PredefinedTemplate.swift
@@ -76,8 +76,8 @@ public struct TemplateMetadata: Sendable {
 }
 
 public extension PredefinedTemplate {
-    /// Cached template metadata for performance.
-    private var cachedMetadata: TemplateMetadata {
+    /// Template metadata computed on demand.
+    private var metadataValue: TemplateMetadata {
         let nameTokens = Self.normalizedTokens(from: rawName)
         let moodList = Self.moods(for: nameTokens)
         let moodTokens = moodList.map(\.rawValue)
@@ -118,17 +118,17 @@ public extension PredefinedTemplate {
 
     /// Tags derived from the template name and mood.
     var tags: [String] {
-        cachedMetadata.tags
+        metadataValue.tags
     }
 
     /// Moods derived from the template name.
     var moods: [TemplateMood] {
-        cachedMetadata.moods
+        metadataValue.moods
     }
 
     /// Combined metadata for the template.
     var metadata: TemplateMetadata {
-        cachedMetadata
+        metadataValue
     }
 
     /// Finds templates that best match the query.

--- a/Tests/MeshingKitTests/MeshingKitTests.swift
+++ b/Tests/MeshingKitTests/MeshingKitTests.swift
@@ -163,6 +163,30 @@ struct MeshingKitTests {
         #expect(results.contains(.size3(.auroraBorealis)))
     }
 
+    @Test("PredefinedTemplate find is case-insensitive")
+    func predefinedTemplateFindCaseInsensitive() {
+        let results = PredefinedTemplate.find(by: "Aurora")
+        #expect(results.contains(.size3(.auroraBorealis)))
+    }
+
+    @Test("PredefinedTemplate find matches moods")
+    func predefinedTemplateFindMoods() {
+        let results = PredefinedTemplate.find(by: "cool")
+        #expect(results.contains(.size2(.arcticFrost)))
+    }
+
+    @Test("PredefinedTemplate find respects limit")
+    func predefinedTemplateFindLimit() {
+        let results = PredefinedTemplate.find(by: "aurora", limit: 1)
+        #expect(results.count == 1)
+    }
+
+    @Test("PredefinedTemplate find returns all for empty query")
+    func predefinedTemplateFindEmptyQuery() {
+        let results = PredefinedTemplate.find(by: "   ")
+        #expect(results.count == PredefinedTemplate.allCases.count)
+    }
+
     @Test("CustomGradientTemplate creates valid template")
     func customGradientTemplateCreation() {
         let points: [SIMD2<Float>] = [
@@ -329,39 +353,40 @@ struct MeshingKitTests {
         #expect(point1.x != point2.x, "Different frequencies should produce different results")
     }
 
-    private struct RGBA {
-        let r: Double
-        let g: Double
-        let b: Double
-        let a: Double
-    }
+}
 
-    private func resolvedRGBA(_ color: Color) -> RGBA {
+private struct RGBA {
+    let r: Double
+    let g: Double
+    let b: Double
+    let a: Double
+}
+
+private func resolvedRGBA(_ color: Color) -> RGBA {
 #if canImport(UIKit)
-        let platformColor = UIColor(color)
-        var r: CGFloat = 0
-        var g: CGFloat = 0
-        var b: CGFloat = 0
-        var a: CGFloat = 0
-        platformColor.getRed(&r, green: &g, blue: &b, alpha: &a)
-        return RGBA(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
+    let platformColor = UIColor(color)
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 0
+    platformColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+    return RGBA(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
 #elseif canImport(AppKit)
-        let platformColor = NSColor(color)
-        let srgb = platformColor.usingColorSpace(.sRGB) ?? platformColor
-        var r: CGFloat = 0
-        var g: CGFloat = 0
-        var b: CGFloat = 0
-        var a: CGFloat = 0
-        srgb.getRed(&r, green: &g, blue: &b, alpha: &a)
-        return RGBA(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
+    let platformColor = NSColor(color)
+    let srgb = platformColor.usingColorSpace(.sRGB) ?? platformColor
+    var r: CGFloat = 0
+    var g: CGFloat = 0
+    var b: CGFloat = 0
+    var a: CGFloat = 0
+    srgb.getRed(&r, green: &g, blue: &b, alpha: &a)
+    return RGBA(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
 #else
-        return RGBA(r: 0, g: 0, b: 0, a: 0)
+    return RGBA(r: 0, g: 0, b: 0, a: 0)
 #endif
-    }
+}
 
-    private func isApproximatelyEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.0001)
-        -> Bool
-    {
-        abs(lhs - rhs) <= tolerance
-    }
+private func isApproximatelyEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.0001)
+    -> Bool
+{
+    abs(lhs - rhs) <= tolerance
 }

--- a/Tests/MeshingKitTests/MeshingKitTests.swift
+++ b/Tests/MeshingKitTests/MeshingKitTests.swift
@@ -144,6 +144,25 @@ struct MeshingKitTests {
         #expect(counts.size4 == 11)
     }
 
+    @Test("PredefinedTemplate tags include name tokens")
+    func predefinedTemplateTags() {
+        let template = PredefinedTemplate.size3(.auroraBorealis)
+        #expect(template.tags.contains("aurora"))
+        #expect(template.tags.contains("borealis"))
+    }
+
+    @Test("PredefinedTemplate moods derived from name")
+    func predefinedTemplateMoods() {
+        let template = PredefinedTemplate.size2(.arcticFrost)
+        #expect(template.moods.contains(.cool))
+    }
+
+    @Test("PredefinedTemplate find by query")
+    func predefinedTemplateFind() {
+        let results = PredefinedTemplate.find(by: "aurora")
+        #expect(results.contains(.size3(.auroraBorealis)))
+    }
+
     @Test("CustomGradientTemplate creates valid template")
     func customGradientTemplateCreation() {
         let points: [SIMD2<Float>] = [


### PR DESCRIPTION
This PR adds metadata and search for predefined templates.

- Adds TemplateMood + TemplateMetadata and derived tags/moods/palette/background.
- Implements PredefinedTemplate.find(by:) with token normalization (uses NaturalLanguage lemmatization when available).
- Adds tests for tags/moods/search and updates README.

Tests:
- swift build
- swiftlint lint
- swift test -c debug