### PR TITLE
Add export helpers for gradients

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,28 @@ This extension supports various hex formats:
 - "#RRGGBB" (24-bit)
 - "#AARRGGBB" (32-bit with alpha)
 
+## Export Helpers
+
+MeshingKit includes helpers to export previews and snippets for design tools:
+
+```swift
+// Snapshot a mesh gradient (CGImage)
+let image = MeshingKit.snapshotCGImage(
+    template: GradientTemplateSize3.auroraBorealis,
+    size: CGSize(width: 600, height: 600)
+)
+
+// Generate SwiftUI Gradient.Stop snippet
+let swiftUIStops = MeshingKit.swiftUIStopsSnippet(
+    template: GradientTemplateSize3.auroraBorealis
+)
+
+// Generate CSS linear-gradient preview
+let css = MeshingKit.cssLinearGradientSnippet(
+    template: GradientTemplateSize3.auroraBorealis
+)
+```
+
 ## Contributing
 
 Contributions to MeshingKit are welcome! Please feel free to submit a Pull Request.

--- a/Sources/MeshingKit/Color+Hex.swift
+++ b/Sources/MeshingKit/Color+Hex.swift
@@ -6,6 +6,18 @@
 //
 
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+struct RGBAComponents {
+    let r: Double
+    let g: Double
+    let b: Double
+    let a: Double
+}
 
 extension Color {
 
@@ -51,5 +63,50 @@ extension Color {
             blue: Double(b) / 255,
             opacity: Double(a) / 255
         )
+    }
+
+    func rgbaComponents() -> RGBAComponents? {
+#if canImport(UIKit)
+        let platformColor = UIColor(self)
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        guard platformColor.getRed(&r, green: &g, blue: &b, alpha: &a) else {
+            return nil
+        }
+        return RGBAComponents(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
+#elseif canImport(AppKit)
+        let platformColor = NSColor(self)
+        let srgb = platformColor.usingColorSpace(.sRGB) ?? platformColor
+        var r: CGFloat = 0
+        var g: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        srgb.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return RGBAComponents(r: Double(r), g: Double(g), b: Double(b), a: Double(a))
+#else
+        return nil
+#endif
+    }
+
+    /// Returns a hex string for the color in sRGB space.
+    ///
+    /// - Parameter includeAlpha: When true, returns #AARRGGBB. Otherwise returns #RRGGBB.
+    /// - Returns: A hex string if the color can be converted to sRGB.
+    public func hexString(includeAlpha: Bool = false) -> String? {
+        guard let components = rgbaComponents() else {
+            return nil
+        }
+
+        let r = Int(round(components.r * 255))
+        let g = Int(round(components.g * 255))
+        let b = Int(round(components.b * 255))
+        let a = Int(round(components.a * 255))
+
+        if includeAlpha {
+            return String(format: "#%02X%02X%02X%02X", a, r, g, b)
+        }
+        return String(format: "#%02X%02X%02X", r, g, b)
     }
 }

--- a/Sources/MeshingKit/GradientExport.swift
+++ b/Sources/MeshingKit/GradientExport.swift
@@ -1,0 +1,217 @@
+//
+//  GradientExport.swift
+//  MeshingKit
+//
+//  Created by Rudrank Riyam on 12/19/25.
+//
+
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+public typealias PlatformImage = UIImage
+#elseif canImport(AppKit)
+import AppKit
+public typealias PlatformImage = NSImage
+#endif
+
+public extension MeshingKit {
+    /// Generates evenly spaced gradient stops for previewing template colors.
+    static func previewStops(template: any GradientTemplate) -> [Gradient.Stop] {
+        let colors = template.colors
+        guard !colors.isEmpty else { return [] }
+
+        let count = colors.count
+        return colors.enumerated().map { index, color in
+            let location = count == 1 ? 0.0 : Double(index) / Double(count - 1)
+            return Gradient.Stop(color: color, location: location)
+        }
+    }
+
+    /// Generates evenly spaced gradient stops for previewing predefined template colors.
+    static func previewStops(template: PredefinedTemplate) -> [Gradient.Stop] {
+        previewStops(template: template.baseTemplate)
+    }
+
+    /// Builds a SwiftUI snippet containing `Gradient.Stop` entries for a template.
+    static func swiftUIStopsSnippet(
+        template: any GradientTemplate,
+        includeAlpha: Bool = false,
+        precision: Int = 2
+    ) -> String {
+        let stops = previewStops(template: template)
+        let format = "%.\(precision)f"
+        let entries = stops.map { stop in
+            let hex = stop.color.hexString(includeAlpha: includeAlpha) ?? "#FFFFFF"
+            let location = String(format: format, stop.location)
+            return ".init(color: Color(hex: \"\(hex)\"), location: \(location))"
+        }
+
+        return "[\(entries.joined(separator: ", "))]"
+    }
+
+    /// Builds a SwiftUI snippet containing `Gradient.Stop` entries for a predefined template.
+    static func swiftUIStopsSnippet(
+        template: PredefinedTemplate,
+        includeAlpha: Bool = false,
+        precision: Int = 2
+    ) -> String {
+        swiftUIStopsSnippet(template: template.baseTemplate, includeAlpha: includeAlpha, precision: precision)
+    }
+
+    /// Builds a CSS `linear-gradient` preview string for a template.
+    static func cssLinearGradientSnippet(
+        template: any GradientTemplate,
+        angle: Double = 90,
+        includeAlpha: Bool = false
+    ) -> String {
+        let stops = previewStops(template: template)
+        let stopDescriptions = stops.map { stop in
+            let percent = Int(round(stop.location * 100))
+            let color = cssColorString(for: stop.color, includeAlpha: includeAlpha)
+            return "\(color) \(percent)%"
+        }
+
+        let angleString = String(format: "%.0f", angle)
+        return "linear-gradient(\(angleString)deg, \(stopDescriptions.joined(separator: ", ")))"
+    }
+
+    /// Builds a CSS `linear-gradient` preview string for a predefined template.
+    static func cssLinearGradientSnippet(
+        template: PredefinedTemplate,
+        angle: Double = 90,
+        includeAlpha: Bool = false
+    ) -> String {
+        cssLinearGradientSnippet(template: template.baseTemplate, angle: angle, includeAlpha: includeAlpha)
+    }
+
+    /// Renders a mesh gradient template to a CGImage snapshot.
+    @MainActor
+    static func snapshotCGImage(
+        template: any GradientTemplate,
+        size: CGSize,
+        scale: CGFloat = 1.0,
+        smoothsColors: Bool = true
+    ) -> CGImage? {
+        let gradient = MeshingKit.gradient(template: template, smoothsColors: smoothsColors)
+            .frame(width: size.width, height: size.height)
+
+        let renderer = ImageRenderer(content: gradient)
+        renderer.scale = scale
+        renderer.proposedSize = ProposedViewSize(width: size.width, height: size.height)
+
+        return renderer.cgImage
+    }
+
+    /// Renders a predefined template to a CGImage snapshot.
+    @MainActor
+    static func snapshotCGImage(
+        template: PredefinedTemplate,
+        size: CGSize,
+        scale: CGFloat = 1.0,
+        smoothsColors: Bool = true
+    ) -> CGImage? {
+        snapshotCGImage(
+            template: template.baseTemplate,
+            size: size,
+            scale: scale,
+            smoothsColors: smoothsColors
+        )
+    }
+
+#if canImport(UIKit)
+    /// Renders a mesh gradient template to a UIImage snapshot.
+    @MainActor
+    static func snapshotImage(
+        template: any GradientTemplate,
+        size: CGSize,
+        scale: CGFloat = 1.0,
+        smoothsColors: Bool = true
+    ) -> UIImage? {
+        guard let cgImage = snapshotCGImage(
+            template: template,
+            size: size,
+            scale: scale,
+            smoothsColors: smoothsColors
+        ) else {
+            return nil
+        }
+        return UIImage(cgImage: cgImage)
+    }
+
+    /// Renders a predefined template to a UIImage snapshot.
+    @MainActor
+    static func snapshotImage(
+        template: PredefinedTemplate,
+        size: CGSize,
+        scale: CGFloat = 1.0,
+        smoothsColors: Bool = true
+    ) -> UIImage? {
+        snapshotImage(
+            template: template.baseTemplate,
+            size: size,
+            scale: scale,
+            smoothsColors: smoothsColors
+        )
+    }
+#elseif canImport(AppKit)
+    /// Renders a mesh gradient template to an NSImage snapshot.
+    @MainActor
+    static func snapshotImage(
+        template: any GradientTemplate,
+        size: CGSize,
+        scale: CGFloat = 1.0,
+        smoothsColors: Bool = true
+    ) -> NSImage? {
+        guard let cgImage = snapshotCGImage(
+            template: template,
+            size: size,
+            scale: scale,
+            smoothsColors: smoothsColors
+        ) else {
+            return nil
+        }
+        return NSImage(cgImage: cgImage, size: size)
+    }
+
+    /// Renders a predefined template to an NSImage snapshot.
+    @MainActor
+    static func snapshotImage(
+        template: PredefinedTemplate,
+        size: CGSize,
+        scale: CGFloat = 1.0,
+        smoothsColors: Bool = true
+    ) -> NSImage? {
+        snapshotImage(
+            template: template.baseTemplate,
+            size: size,
+            scale: scale,
+            smoothsColors: smoothsColors
+        )
+    }
+#endif
+}
+
+private extension MeshingKit {
+    static func cssColorString(for color: Color, includeAlpha: Bool) -> String {
+        guard includeAlpha, let components = color.rgbaComponents() else {
+            return color.hexString() ?? "#FFFFFF"
+        }
+
+        let r = Int(round(components.r * 255))
+        let g = Int(round(components.g * 255))
+        let b = Int(round(components.b * 255))
+        let a = String(format: "%.2f", components.a)
+        return "rgba(\(r), \(g), \(b), \(a))"
+    }
+}
+
+private extension PredefinedTemplate {
+    var baseTemplate: any GradientTemplate {
+        switch self {
+        case .size2(let specificTemplate): return specificTemplate
+        case .size3(let specificTemplate): return specificTemplate
+        case .size4(let specificTemplate): return specificTemplate
+        }
+    }
+}

--- a/Sources/MeshingKit/GradientExport.swift
+++ b/Sources/MeshingKit/GradientExport.swift
@@ -194,15 +194,19 @@ public extension MeshingKit {
 
 private extension MeshingKit {
     static func cssColorString(for color: Color, includeAlpha: Bool) -> String {
-        guard includeAlpha, let components = color.rgbaComponents() else {
-            return color.hexString() ?? "#FFFFFF"
+        if includeAlpha {
+            if let components = color.rgbaComponents() {
+                let r = Int(round(components.r * 255))
+                let g = Int(round(components.g * 255))
+                let b = Int(round(components.b * 255))
+                let a = String(format: "%.2f", components.a)
+                return "rgba(\(r), \(g), \(b), \(a))"
+            }
+
+            return color.hexString(includeAlpha: true) ?? "#FFFFFFFF"
         }
 
-        let r = Int(round(components.r * 255))
-        let g = Int(round(components.g * 255))
-        let b = Int(round(components.b * 255))
-        let a = String(format: "%.2f", components.a)
-        return "rgba(\(r), \(g), \(b), \(a))"
+        return color.hexString() ?? "#FFFFFF"
     }
 }
 

--- a/Sources/MeshingKit/GradientExport.swift
+++ b/Sources/MeshingKit/GradientExport.swift
@@ -194,28 +194,13 @@ public extension MeshingKit {
 
 private extension MeshingKit {
     static func cssColorString(for color: Color, includeAlpha: Bool) -> String {
-        if includeAlpha {
-            if let components = color.rgbaComponents() {
-                let r = Int(round(components.r * 255))
-                let g = Int(round(components.g * 255))
-                let b = Int(round(components.b * 255))
-                let a = String(format: "%.2f", components.a)
-                return "rgba(\(r), \(g), \(b), \(a))"
-            }
-
-            return color.hexString(includeAlpha: true) ?? "#FFFFFFFF"
+        if includeAlpha, let components = color.rgbaComponents() {
+            let r = Int(round(components.r * 255))
+            let g = Int(round(components.g * 255))
+            let b = Int(round(components.b * 255))
+            let a = String(format: "%.2f", components.a)
+            return "rgba(\(r), \(g), \(b), \(a))"
         }
-
-        return color.hexString() ?? "#FFFFFF"
-    }
-}
-
-private extension PredefinedTemplate {
-    var baseTemplate: any GradientTemplate {
-        switch self {
-        case .size2(let specificTemplate): return specificTemplate
-        case .size3(let specificTemplate): return specificTemplate
-        case .size4(let specificTemplate): return specificTemplate
-        }
+        return color.hexString(includeAlpha: includeAlpha) ?? "#FFFFFF"
     }
 }

--- a/Sources/MeshingKit/MeshingKit.swift
+++ b/Sources/MeshingKit/MeshingKit.swift
@@ -139,13 +139,7 @@ public struct MeshingKit: Sendable {
     )
         -> MeshGradient
     {
-        let baseTemplate: any GradientTemplate = switch template {
-        case .size2(let specificTemplate): specificTemplate
-        case .size3(let specificTemplate): specificTemplate
-        case .size4(let specificTemplate): specificTemplate
-        }
-
-        return gradient(template: baseTemplate, smoothsColors: smoothsColors)
+        gradient(template: template.baseTemplate, smoothsColors: smoothsColors)
     }
 
     /// Creates an animated `MeshGradient` view from any gradient template.
@@ -222,14 +216,8 @@ public struct MeshingKit: Sendable {
         animationPattern: AnimationPattern? = nil,
         smoothsColors: Bool = true
     ) -> some View {
-        let baseTemplate: any GradientTemplate = switch template {
-        case .size2(let specificTemplate): specificTemplate
-        case .size3(let specificTemplate): specificTemplate
-        case .size4(let specificTemplate): specificTemplate
-        }
-
-        return animatedGradient(
-            baseTemplate,
+        animatedGradient(
+            template.baseTemplate,
             showAnimation: showAnimation,
             animationSpeed: animationSpeed,
             animationPattern: animationPattern,

--- a/Sources/MeshingKit/PredefinedTemplate.swift
+++ b/Sources/MeshingKit/PredefinedTemplate.swift
@@ -33,4 +33,13 @@ public enum PredefinedTemplate: Identifiable, CaseIterable {
         case .size4(let template): return "size4_\(template.rawValue)"
         }
     }
+
+    /// Returns the underlying base template for this predefined template.
+    var baseTemplate: any GradientTemplate {
+        switch self {
+        case .size2(let template): return template
+        case .size3(let template): return template
+        case .size4(let template): return template
+        }
+    }
 }

--- a/Tests/MeshingKitTests/MeshingKitTests.swift
+++ b/Tests/MeshingKitTests/MeshingKitTests.swift
@@ -93,6 +93,13 @@ struct MeshingKitTests {
         }
     }
 
+    @Test("Hex color extension outputs hex string")
+    func hexColorOutputsHexString() {
+        let color = Color(hex: "#FF0000")
+        #expect(color.hexString() == "#FF0000")
+        #expect(color.hexString(includeAlpha: true) == "#FFFF0000")
+    }
+
     private func validateTemplates<T: GradientTemplate>(
         _ templates: [T],
         expectedSize: Int
@@ -142,6 +149,27 @@ struct MeshingKitTests {
         #expect(counts.size2 == 35)
         #expect(counts.size3 == 22)
         #expect(counts.size4 == 11)
+    }
+
+    @Test("Export helpers generate snippets")
+    func exportHelpersSnippets() {
+        let template = GradientTemplateSize2.mysticTwilight
+        let swiftUIStops = MeshingKit.swiftUIStopsSnippet(template: template)
+        let cssStops = MeshingKit.cssLinearGradientSnippet(template: template)
+
+        #expect(swiftUIStops.contains("Color(hex:"))
+        #expect(cssStops.contains("linear-gradient("))
+        #expect(cssStops.contains("#"))
+    }
+
+    @Test("Export helpers generate stops")
+    func exportHelpersStops() {
+        let template = GradientTemplateSize2.mysticTwilight
+        let stops = MeshingKit.previewStops(template: template)
+
+        #expect(stops.count == template.colors.count)
+        #expect(isApproximatelyEqual(Double(stops.first?.location ?? 0), 0))
+        #expect(isApproximatelyEqual(Double(stops.last?.location ?? 0), 1))
     }
 
     @Test("CustomGradientTemplate creates valid template")

--- a/Tests/MeshingKitTests/MeshingKitTests.swift
+++ b/Tests/MeshingKitTests/MeshingKitTests.swift
@@ -155,11 +155,21 @@ struct MeshingKitTests {
     func exportHelpersSnippets() {
         let template = GradientTemplateSize2.mysticTwilight
         let swiftUIStops = MeshingKit.swiftUIStopsSnippet(template: template)
+        let swiftUIStopsWithAlpha = MeshingKit.swiftUIStopsSnippet(
+            template: template,
+            includeAlpha: true
+        )
         let cssStops = MeshingKit.cssLinearGradientSnippet(template: template)
+        let cssStopsWithAlpha = MeshingKit.cssLinearGradientSnippet(
+            template: template,
+            includeAlpha: true
+        )
 
         #expect(swiftUIStops.contains("Color(hex:"))
+        #expect(swiftUIStopsWithAlpha.contains("Color(hex: \"#FF"))
         #expect(cssStops.contains("linear-gradient("))
         #expect(cssStops.contains("#"))
+        #expect(cssStopsWithAlpha.contains("rgba("))
     }
 
     @Test("Export helpers generate stops")


### PR DESCRIPTION
This PR adds export helpers for snapshots and preview snippets.

- Adds snapshot helpers to render MeshGradient to CGImage/PlatformImage.
- Adds SwiftUI + CSS color stop snippet helpers for design tools.
- Adds Color hex output and tests + README examples.

Tests:
- swift build
- swiftlint lint
- swift test -c debug