### PR TITLE
Fix export safety issues and audit findings

### DIFF
--- a/Sources/Meshin/Meshin/MeshinViewModel.swift
+++ b/Sources/Meshin/Meshin/MeshinViewModel.swift
@@ -38,8 +38,8 @@ final class MeshinViewModel: ObservableObject {
     func saveToPhotoLibrary() {
         guard let template = selectedTemplate else { return }
 
+        clearMessages()
         isExporting = true
-        exportError = nil
 
         MeshingKit.saveGradientToPhotoAlbum(
             template: template,
@@ -61,8 +61,8 @@ final class MeshinViewModel: ObservableObject {
     func exportVideoToPhotoLibrary() {
         guard let template = selectedTemplate else { return }
 
+        clearMessages()
         isExporting = true
-        exportError = nil
 
         MeshingKit.exportVideoToPhotoLibrary(
             template: template,
@@ -88,8 +88,8 @@ final class MeshinViewModel: ObservableObject {
     func saveToDisk(format: ExportFormat) {
         guard let template = selectedTemplate else { return }
 
+        clearMessages()
         isExporting = true
-        exportError = nil
 
         MeshingKit.saveGradientToDisk(
             template: template,
@@ -116,8 +116,8 @@ final class MeshinViewModel: ObservableObject {
     func exportVideoToDisk() {
         guard let template = selectedTemplate else { return }
 
+        clearMessages()
         isExporting = true
-        exportError = nil
 
         MeshingKit.exportVideoToDisk(
             template: template,

--- a/Sources/MeshingKit/Color+Hex.swift
+++ b/Sources/MeshingKit/Color+Hex.swift
@@ -32,23 +32,29 @@ extension Color {
     ///                  The "#" prefix is optional.
     ///
     /// - Note: If an invalid hex string is provided, the color will default to opaque white.
-    init(hex: String) {
-        let hex = hex.trimmingCharacters(
-            in: CharacterSet.alphanumerics.inverted)
-        var int: UInt64 = 0
-        let scanned = Scanner(string: hex).scanHexInt64(&int)
+    public init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        let validHexDigits = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        let isValidLength = hex.count == 3 || hex.count == 6 || hex.count == 8
+        let hasOnlyHexDigits = !hex.isEmpty && hex.unicodeScalars.allSatisfy { validHexDigits.contains($0) }
+
+        guard isValidLength, hasOnlyHexDigits, let int = UInt64(hex, radix: 16) else {
+            self.init(.sRGB, red: 1, green: 1, blue: 1, opacity: 1)
+            return
+        }
+
         let a: UInt64
         let r: UInt64
         let g: UInt64
         let b: UInt64
-        switch (scanned, hex.count) {
-        case (true, 3):  // RGB (12-bit)
+        switch hex.count {
+        case 3:  // RGB (12-bit)
             (a, r, g, b) = (
                 255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17
             )
-        case (true, 6):  // RGB (24-bit)
+        case 6:  // RGB (24-bit)
             (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case (true, 8):  // ARGB (32-bit)
+        case 8:  // ARGB (32-bit)
             (a, r, g, b) = (
                 int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF
             )

--- a/Sources/MeshingKit/GradientExport+iOS.swift
+++ b/Sources/MeshingKit/GradientExport+iOS.swift
@@ -87,23 +87,7 @@ public extension MeshingKit {
             .frame(width: size.width, height: size.height)
             .overlay(alignment: .topLeading) {
                 if showDots {
-                    ZStack {
-                        ForEach(Array(points.indices), id: \.self) { index in
-                            let point = points[index]
-                            let dotColor = colors.indices.contains(index) ? colors[index] : .white
-                            Circle()
-                                .fill(dotColor.opacity(0.9))
-                                .frame(width: 10, height: 10)
-                                .overlay(
-                                    Circle().stroke(Color.white.opacity(0.9), lineWidth: 1)
-                                )
-                                .position(
-                                    x: CGFloat(point.x) * size.width,
-                                    y: CGFloat(point.y) * size.height
-                                )
-                        }
-                    }
-                    .frame(width: size.width, height: size.height, alignment: .topLeading)
+                    MeshingKit.controlPointsOverlay(points: points, colors: colors, size: size)
                 }
             }
             .blur(radius: blurRadius)

--- a/Sources/MeshingKit/GradientExport+iOS.swift
+++ b/Sources/MeshingKit/GradientExport+iOS.swift
@@ -72,17 +72,41 @@ public extension MeshingKit {
         smoothsColors: Bool = true,
         completion: @escaping @Sendable (Result<Void, Error>) -> Void
     ) {
+        let points = template.points
+        let colors = template.colors
+
         let renderer = ImageRenderer(
             content: MeshGradient(
                 width: template.size,
                 height: template.size,
-                locations: .points(template.points),
-                colors: .colors(template.colors),
+                locations: .points(points),
+                colors: .colors(colors),
                 background: template.background,
                 smoothsColors: smoothsColors
             )
-            .blur(radius: blurRadius)
             .frame(width: size.width, height: size.height)
+            .overlay(alignment: .topLeading) {
+                if showDots {
+                    ZStack {
+                        ForEach(Array(points.indices), id: \.self) { index in
+                            let point = points[index]
+                            let dotColor = colors.indices.contains(index) ? colors[index] : .white
+                            Circle()
+                                .fill(dotColor.opacity(0.9))
+                                .frame(width: 10, height: 10)
+                                .overlay(
+                                    Circle().stroke(Color.white.opacity(0.9), lineWidth: 1)
+                                )
+                                .position(
+                                    x: CGFloat(point.x) * size.width,
+                                    y: CGFloat(point.y) * size.height
+                                )
+                        }
+                    }
+                    .frame(width: size.width, height: size.height, alignment: .topLeading)
+                }
+            }
+            .blur(radius: blurRadius)
             .cornerRadius(showDots ? 0 : 12)
         )
         renderer.scale = scale

--- a/Sources/MeshingKit/GradientExport+macOS.swift
+++ b/Sources/MeshingKit/GradientExport+macOS.swift
@@ -151,17 +151,40 @@ public extension MeshingKit {
         completion: @escaping (Result<URL, Error>) -> Void
     ) {
         let cornerRadius: CGFloat = showDots ? 0 : 12
+        let points = template.points
+        let colors = template.colors
         let renderer = ImageRenderer(
             content: MeshGradient(
                 width: template.size,
                 height: template.size,
-                locations: .points(template.points),
-                colors: .colors(template.colors),
+                locations: .points(points),
+                colors: .colors(colors),
                 background: template.background,
                 smoothsColors: smoothsColors
             )
-            .blur(radius: blurRadius)
             .frame(width: size.width, height: size.height)
+            .overlay(alignment: .topLeading) {
+                if showDots {
+                    ZStack {
+                        ForEach(Array(points.indices), id: \.self) { index in
+                            let point = points[index]
+                            let dotColor = colors.indices.contains(index) ? colors[index] : .white
+                            Circle()
+                                .fill(dotColor.opacity(0.9))
+                                .frame(width: 10, height: 10)
+                                .overlay(
+                                    Circle().stroke(Color.white.opacity(0.9), lineWidth: 1)
+                                )
+                                .position(
+                                    x: CGFloat(point.x) * size.width,
+                                    y: CGFloat(point.y) * size.height
+                                )
+                        }
+                    }
+                    .frame(width: size.width, height: size.height, alignment: .topLeading)
+                }
+            }
+            .blur(radius: blurRadius)
             .cornerRadius(cornerRadius)
         )
         renderer.scale = scale

--- a/Sources/MeshingKit/GradientExport+macOS.swift
+++ b/Sources/MeshingKit/GradientExport+macOS.swift
@@ -165,23 +165,7 @@ public extension MeshingKit {
             .frame(width: size.width, height: size.height)
             .overlay(alignment: .topLeading) {
                 if showDots {
-                    ZStack {
-                        ForEach(Array(points.indices), id: \.self) { index in
-                            let point = points[index]
-                            let dotColor = colors.indices.contains(index) ? colors[index] : .white
-                            Circle()
-                                .fill(dotColor.opacity(0.9))
-                                .frame(width: 10, height: 10)
-                                .overlay(
-                                    Circle().stroke(Color.white.opacity(0.9), lineWidth: 1)
-                                )
-                                .position(
-                                    x: CGFloat(point.x) * size.width,
-                                    y: CGFloat(point.y) * size.height
-                                )
-                        }
-                    }
-                    .frame(width: size.width, height: size.height, alignment: .topLeading)
+                    MeshingKit.controlPointsOverlay(points: points, colors: colors, size: size)
                 }
             }
             .blur(radius: blurRadius)

--- a/Sources/MeshingKit/GradientExport.swift
+++ b/Sources/MeshingKit/GradientExport.swift
@@ -263,3 +263,36 @@ private extension MeshingKit {
         return color.hexString(includeAlpha: includeAlpha) ?? "#FFFFFF"
     }
 }
+
+extension MeshingKit {
+    @ViewBuilder
+    static func controlPointsOverlay(
+        points: [SIMD2<Float>],
+        colors: [Color],
+        size: CGSize
+    ) -> some View {
+        Canvas { context, _ in
+            let radius: CGFloat = 5
+            let strokeColor = Color.white.opacity(0.9)
+
+            for (index, point) in points.enumerated() {
+                let center = CGPoint(
+                    x: CGFloat(point.x) * size.width,
+                    y: CGFloat(point.y) * size.height
+                )
+                let rect = CGRect(
+                    x: center.x - radius,
+                    y: center.y - radius,
+                    width: radius * 2,
+                    height: radius * 2
+                )
+                let path = Path(ellipseIn: rect)
+                let fillColor = colors.indices.contains(index) ? colors[index].opacity(0.9) : Color.white.opacity(0.9)
+
+                context.fill(path, with: .color(fillColor))
+                context.stroke(path, with: .color(strokeColor), lineWidth: 1)
+            }
+        }
+        .frame(width: size.width, height: size.height)
+    }
+}

--- a/Sources/MeshingKit/GradientVideoExport.swift
+++ b/Sources/MeshingKit/GradientVideoExport.swift
@@ -129,7 +129,8 @@ public extension MeshingKit {
             size: size,
             duration: duration,
             frameRate: frameRate,
-            renderScale: renderScale
+            renderScale: renderScale,
+            timeout: timeout
         )
 
         let config = VideoExportConfiguration(
@@ -205,6 +206,7 @@ public extension MeshingKit {
 
     private static func performVideoExport(params: VideoExportParams) async throws -> URL {
         let outputURLCopy = params.outputURL
+        let timeoutNanoseconds = try timeoutToNanoseconds(params.timeout)
 
         do {
             return try await withThrowingTaskGroup(of: URL.self) { group in
@@ -229,7 +231,7 @@ public extension MeshingKit {
                 }
 
                 group.addTask {
-                    try await Task.sleep(nanoseconds: UInt64(params.timeout * 1_000_000_000))
+                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
                     throw VideoExportError.videoExportTimedOut(params.timeout)
                 }
 
@@ -292,7 +294,8 @@ private extension MeshingKit {
         size: CGSize,
         duration: TimeInterval,
         frameRate: Int32,
-        renderScale: CGFloat
+        renderScale: CGFloat,
+        timeout: TimeInterval
     ) throws {
         guard validateDuration(duration) else {
             throw VideoExportError.invalidConfiguration(
@@ -319,6 +322,14 @@ private extension MeshingKit {
                 renderScale.isFinite && renderScale > 0
                     ? "Render scale must not exceed 4.0."
                     : "Render scale must be finite and greater than 0."
+            )
+        }
+
+        guard validateTimeout(timeout) else {
+            throw VideoExportError.invalidConfiguration(
+                timeout.isFinite && timeout > 0
+                    ? "Timeout is too large."
+                    : "Timeout must be finite and greater than 0."
             )
         }
 
@@ -353,6 +364,23 @@ private extension MeshingKit {
 
     private static func validateRenderScale(_ renderScale: CGFloat) -> Bool {
         renderScale.isFinite && renderScale > 0 && renderScale <= 4.0
+    }
+
+    private static func validateTimeout(_ timeout: TimeInterval) -> Bool {
+        let timeoutNanoseconds = timeout * 1_000_000_000
+        return timeout.isFinite && timeout > 0
+            && timeoutNanoseconds.isFinite && timeoutNanoseconds <= Double(UInt64.max)
+    }
+
+    private static func timeoutToNanoseconds(_ timeout: TimeInterval) throws -> UInt64 {
+        guard validateTimeout(timeout) else {
+            throw VideoExportError.invalidConfiguration(
+                timeout.isFinite && timeout > 0
+                    ? "Timeout is too large."
+                    : "Timeout must be finite and greater than 0."
+            )
+        }
+        return UInt64((timeout * 1_000_000_000).rounded(.down))
     }
 }
 #endif

--- a/Sources/MeshingKit/GradientVideoExport.swift
+++ b/Sources/MeshingKit/GradientVideoExport.swift
@@ -369,7 +369,7 @@ private extension MeshingKit {
     private static func validateTimeout(_ timeout: TimeInterval) -> Bool {
         let timeoutNanoseconds = timeout * 1_000_000_000
         return timeout.isFinite && timeout > 0
-            && timeoutNanoseconds.isFinite && timeoutNanoseconds <= Double(UInt64.max)
+            && timeoutNanoseconds.isFinite && timeoutNanoseconds < Double(UInt64.max)
     }
 
     private static func timeoutToNanoseconds(_ timeout: TimeInterval) throws -> UInt64 {

--- a/Sources/MeshingKit/GradientVideoExportInternals.swift
+++ b/Sources/MeshingKit/GradientVideoExportInternals.swift
@@ -221,8 +221,6 @@ public extension MeshingKit {
 
             context.clear(CGRect(x: 0, y: 0, width: width, height: height))
             context.interpolationQuality = .high
-            context.translateBy(x: 0, y: CGFloat(height))
-            context.scaleBy(x: 1, y: -1)
             context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
 
             return buffer

--- a/Sources/MeshingKit/GradientVideoExportInternals.swift
+++ b/Sources/MeshingKit/GradientVideoExportInternals.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 #if canImport(AVFoundation) && canImport(CoreImage) && (canImport(UIKit) || canImport(AppKit))
 import AVFoundation
-import CoreImage
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -19,21 +18,19 @@ import AppKit
 public extension MeshingKit {
     actor FrameLoopDriver {
         private let assetConfig: AssetWriterConfig
-        private let context: CIContext
         private let frameDuration: CMTime
         private let state: VideoWriterState
         private var isWriting = false
+        private var cachedStaticFrame: CGImage?
 
         fileprivate static let minimumAverageBitrate = 2_000_000
 
         init(
             assetConfig: AssetWriterConfig,
-            context: CIContext,
             frameDuration: CMTime,
             state: VideoWriterState
         ) {
             self.assetConfig = assetConfig
-            self.context = context
             self.frameDuration = frameDuration
             self.state = state
         }
@@ -74,29 +71,51 @@ public extension MeshingKit {
             while assetConfig.writerInput.isReadyForMoreMediaData
                 && state.frameIndex < loopConfig.totalFrames {
                 let index = state.frameIndex
-                let phase = Double(index) * loopConfig.timePerFrame
+                let frameImage: CGImage
 
-                guard let image = await MainActor.run(
-                    body: {
-                        renderFrame(
-                            at: phase,
-                            size: loopConfig.viewSize,
-                            snapshot: loopConfig.snapshot
+                if loopConfig.snapshot.shouldAnimate {
+                    let points = loopConfig.points(forFrame: index)
+                    guard let renderedFrame = await MainActor.run(
+                        body: {
+                            renderFrame(
+                                points: points,
+                                size: loopConfig.viewSize,
+                                snapshot: loopConfig.snapshot
+                            )
+                        }
+                    ) else {
+                        state.isFinished = true
+                        continuationHolder.resume(throwing: VideoExportError.frameRenderingFailed)
+                        return
+                    }
+                    frameImage = renderedFrame
+                } else {
+                    if cachedStaticFrame == nil {
+                        cachedStaticFrame = await MainActor.run(
+                            body: {
+                                renderFrame(
+                                    points: loopConfig.snapshot.positions,
+                                    size: loopConfig.viewSize,
+                                    snapshot: loopConfig.snapshot
+                                )
+                            }
                         )
                     }
-                ) else {
-                    state.isFinished = true
-                    continuationHolder.resume(throwing: VideoExportError.frameRenderingFailed)
-                    return
+
+                    guard let staticFrame = cachedStaticFrame else {
+                        state.isFinished = true
+                        continuationHolder.resume(throwing: VideoExportError.frameRenderingFailed)
+                        return
+                    }
+                    frameImage = staticFrame
                 }
 
                 let presentationTime = CMTimeMultiply(frameDuration, multiplier: Int32(index))
 
                 if let error = Self.processFrame(
-                    image: image,
+                    cgImage: frameImage,
                     presentationTime: presentationTime,
                     adaptor: assetConfig.adaptor,
-                    context: context,
                     targetSize: loopConfig.outputSize
                 ) {
                     state.isFinished = true
@@ -139,10 +158,9 @@ public extension MeshingKit {
         }
 
         private static func processFrame(
-            image: PlatformImage,
+            cgImage: CGImage,
             presentationTime: CMTime,
             adaptor: AVAssetWriterInputPixelBufferAdaptor,
-            context: CIContext,
             targetSize: CGSize
         ) -> VideoExportError? {
             guard let pixelBufferPool = adaptor.pixelBufferPool else {
@@ -150,9 +168,8 @@ public extension MeshingKit {
             }
 
             guard let pixelBuffer = Self.pixelBuffer(
-                from: image,
+                from: cgImage,
                 pixelBufferPool: pixelBufferPool,
-                context: context,
                 targetSize: targetSize
             ) else {
                 return .pixelBufferCreationFailed
@@ -166,15 +183,10 @@ public extension MeshingKit {
         }
 
         private static func pixelBuffer(
-            from image: PlatformImage,
+            from cgImage: CGImage,
             pixelBufferPool: CVPixelBufferPool,
-            context: CIContext,
             targetSize: CGSize
         ) -> CVPixelBuffer? {
-            guard let cgImage = Self.cgImage(from: image) else {
-                return nil
-            }
-
             var pixelBuffer: CVPixelBuffer?
             CVPixelBufferPoolCreatePixelBuffer(nil, pixelBufferPool, &pixelBuffer)
 
@@ -182,40 +194,49 @@ public extension MeshingKit {
                 return nil
             }
 
-            let ciImage = CIImage(cgImage: cgImage)
-
             CVPixelBufferLockBaseAddress(buffer, [])
             defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
 
-            let bounds = CGRect(origin: .zero, size: targetSize)
-            context.render(ciImage, to: buffer, bounds: bounds, colorSpace: CGColorSpaceCreateDeviceRGB())
+            guard let baseAddress = CVPixelBufferGetBaseAddress(buffer) else {
+                return nil
+            }
+
+            let width = Int(targetSize.width)
+            let height = Int(targetSize.height)
+            let bytesPerRow = CVPixelBufferGetBytesPerRow(buffer)
+            let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
+                | CGBitmapInfo.byteOrder32Little.rawValue
+
+            guard let context = CGContext(
+                data: baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: Self.rgbColorSpace,
+                bitmapInfo: bitmapInfo
+            ) else {
+                return nil
+            }
+
+            context.clear(CGRect(x: 0, y: 0, width: width, height: height))
+            context.interpolationQuality = .high
+            context.translateBy(x: 0, y: CGFloat(height))
+            context.scaleBy(x: 1, y: -1)
+            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
 
             return buffer
         }
 
-        private static func cgImage(from image: PlatformImage) -> CGImage? {
-            #if canImport(UIKit)
-            return image.cgImage
-            #elseif canImport(AppKit)
-            return image.cgImage(forProposedRect: nil, context: nil, hints: nil)
-            #else
-            return nil
-            #endif
-        }
+        private static let rgbColorSpace = CGColorSpaceCreateDeviceRGB()
     }
 
     @MainActor
     private static func renderFrame(
-        at progress: Double,
+        points: [SIMD2<Float>],
         size: CGSize,
         snapshot: VideoExportSnapshot
-    ) -> PlatformImage? {
-        let points = animatedPositions(
-            for: progress,
-            positions: snapshot.positions,
-            animate: snapshot.shouldAnimate
-        )
-
+    ) -> CGImage? {
         let frame = MeshGradient(
             width: snapshot.gridSize,
             height: snapshot.gridSize,
@@ -227,23 +248,11 @@ public extension MeshingKit {
         .frame(width: size.width, height: size.height)
         .overlay(alignment: .topLeading) {
             if snapshot.showDots {
-                ZStack {
-                    ForEach(Array(points.indices), id: \.self) { index in
-                        let point = points[index]
-                        let dotColor = snapshot.colors.indices.contains(index) ? snapshot.colors[index] : .white
-                        Circle()
-                            .fill(dotColor.opacity(0.9))
-                            .frame(width: 10, height: 10)
-                            .overlay(
-                                Circle().stroke(Color.white.opacity(0.9), lineWidth: 1)
-                            )
-                            .position(
-                                x: CGFloat(point.x) * size.width,
-                                y: CGFloat(point.y) * size.height
-                            )
-                    }
-                }
-                .frame(width: size.width, height: size.height, alignment: .topLeading)
+                MeshingKit.controlPointsOverlay(
+                    points: points,
+                    colors: snapshot.colors,
+                    size: size
+                )
             }
         }
         .blur(radius: snapshot.blurRadius)
@@ -252,13 +261,8 @@ public extension MeshingKit {
 
         let renderer = ImageRenderer(content: frame)
         renderer.scale = snapshot.renderScale
-        #if canImport(UIKit)
-        return renderer.uiImage
-        #elseif canImport(AppKit)
-        return renderer.nsImage
-        #else
-        return nil
-        #endif
+        renderer.proposedSize = ProposedViewSize(width: size.width, height: size.height)
+        return renderer.cgImage
     }
 
     static func configureAssetWriter(

--- a/Sources/MeshingKit/GradientVideoExportInternals.swift
+++ b/Sources/MeshingKit/GradientVideoExportInternals.swift
@@ -40,16 +40,23 @@ public extension MeshingKit {
 
         fileprivate func startWriting(
             loopConfig: FrameLoopConfig,
-            continuation: CheckedContinuation<Void, Error>,
             continuationHolder: ContinuationHolder
         ) {
+            guard !state.isFinished else { return }
+            guard assetConfig.assetWriter.status == .writing else {
+                state.isFinished = true
+                continuationHolder.resume(
+                    throwing: assetConfig.assetWriter.error ?? VideoExportError.failedToStartWriting
+                )
+                return
+            }
+
             assetConfig.writerInput.requestMediaDataWhenReady(
                 on: DispatchQueue(label: "meshing.video.writer")
             ) {
                 Task {
                     await self.writeFrames(
                         loopConfig: loopConfig,
-                        continuation: continuation,
                         continuationHolder: continuationHolder
                     )
                 }
@@ -58,7 +65,6 @@ public extension MeshingKit {
 
         private func writeFrames(
             loopConfig: FrameLoopConfig,
-            continuation: CheckedContinuation<Void, Error>,
             continuationHolder: ContinuationHolder
         ) async {
             guard !state.isFinished, !isWriting else { return }
@@ -80,8 +86,7 @@ public extension MeshingKit {
                     }
                 ) else {
                     state.isFinished = true
-                    continuationHolder.markResumed()
-                    continuation.resume(throwing: VideoExportError.frameRenderingFailed)
+                    continuationHolder.resume(throwing: VideoExportError.frameRenderingFailed)
                     return
                 }
 
@@ -95,8 +100,7 @@ public extension MeshingKit {
                     targetSize: loopConfig.outputSize
                 ) {
                     state.isFinished = true
-                    continuationHolder.markResumed()
-                    continuation.resume(throwing: error)
+                    continuationHolder.resume(throwing: error)
                     return
                 }
 
@@ -109,7 +113,6 @@ public extension MeshingKit {
                 assetConfig.assetWriter.finishWriting {
                     Task {
                         await self.handleFinish(
-                            continuation: continuation,
                             continuationHolder: continuationHolder
                         )
                     }
@@ -118,14 +121,12 @@ public extension MeshingKit {
         }
 
         private func handleFinish(
-            continuation: CheckedContinuation<Void, Error>,
             continuationHolder: ContinuationHolder
         ) {
-            continuationHolder.markResumed()
             if let error = assetConfig.assetWriter.error {
-                continuation.resume(throwing: error)
+                continuationHolder.resume(throwing: error)
             } else {
-                continuation.resume()
+                continuationHolder.resume()
             }
         }
 
@@ -135,18 +136,6 @@ public extension MeshingKit {
             assetConfig.writerInput.markAsFinished()
             assetConfig.assetWriter.cancelWriting()
             try? FileManager.default.removeItem(at: outputURL)
-        }
-
-        func cancelWithContinuation(
-            outputURL: URL,
-            continuation: CheckedContinuation<Void, Error>
-        ) {
-            guard !state.isFinished else { return }
-            state.isFinished = true
-            assetConfig.writerInput.markAsFinished()
-            assetConfig.assetWriter.cancelWriting()
-            try? FileManager.default.removeItem(at: outputURL)
-            continuation.resume(throwing: CancellationError())
         }
 
         private static func processFrame(
@@ -236,6 +225,27 @@ public extension MeshingKit {
             smoothsColors: snapshot.smoothsColors
         )
         .frame(width: size.width, height: size.height)
+        .overlay(alignment: .topLeading) {
+            if snapshot.showDots {
+                ZStack {
+                    ForEach(Array(points.indices), id: \.self) { index in
+                        let point = points[index]
+                        let dotColor = snapshot.colors.indices.contains(index) ? snapshot.colors[index] : .white
+                        Circle()
+                            .fill(dotColor.opacity(0.9))
+                            .frame(width: 10, height: 10)
+                            .overlay(
+                                Circle().stroke(Color.white.opacity(0.9), lineWidth: 1)
+                            )
+                            .position(
+                                x: CGFloat(point.x) * size.width,
+                                y: CGFloat(point.y) * size.height
+                            )
+                    }
+                }
+                .frame(width: size.width, height: size.height, alignment: .topLeading)
+            }
+        }
         .blur(radius: snapshot.blurRadius)
         .clipped()
         .cornerRadius(snapshot.showDots ? 0 : 12)
@@ -332,7 +342,6 @@ public extension MeshingKit {
                     Task {
                         await loopDriver.startWriting(
                             loopConfig: loopConfig,
-                            continuation: continuation,
                             continuationHolder: continuationHolder
                         )
                     }

--- a/Sources/MeshingKit/GradientVideoExportTypes.swift
+++ b/Sources/MeshingKit/GradientVideoExportTypes.swift
@@ -26,28 +26,58 @@ public extension MeshingKit {
     final class ContinuationHolder: @unchecked Sendable {
         private let lock = NSLock()
         private var continuation: CheckedContinuation<Void, Error>?
-        private var hasResumed = false
+        private var completion: Result<Void, Error>?
 
         func set(_ continuation: CheckedContinuation<Void, Error>) {
+            var pendingCompletion: Result<Void, Error>?
             lock.lock()
-            defer { lock.unlock() }
-            self.continuation = continuation
+            if let completion {
+                pendingCompletion = completion
+            } else {
+                self.continuation = continuation
+            }
+            lock.unlock()
+
+            guard let pendingCompletion else { return }
+            switch pendingCompletion {
+            case .success:
+                continuation.resume()
+            case .failure(let error):
+                continuation.resume(throwing: error)
+            }
         }
 
         func resumeWithCancellation() {
-            lock.lock()
-            defer { lock.unlock() }
-            guard !hasResumed, let cont = continuation else { return }
-            hasResumed = true
-            continuation = nil
-            cont.resume(throwing: CancellationError())
+            resume(throwing: CancellationError())
         }
 
-        func markResumed() {
+        func resume(throwing error: Error) {
+            complete(with: .failure(error))
+        }
+
+        func resume() {
+            complete(with: .success(()))
+        }
+
+        private func complete(with result: Result<Void, Error>) {
+            var continuationToResume: CheckedContinuation<Void, Error>?
             lock.lock()
-            defer { lock.unlock() }
-            hasResumed = true
+            guard completion == nil else {
+                lock.unlock()
+                return
+            }
+            completion = result
+            continuationToResume = continuation
             continuation = nil
+            lock.unlock()
+
+            guard let continuationToResume else { return }
+            switch result {
+            case .success:
+                continuationToResume.resume()
+            case .failure(let error):
+                continuationToResume.resume(throwing: error)
+            }
         }
     }
 

--- a/Sources/MeshingKit/GradientVideoExportTypes.swift
+++ b/Sources/MeshingKit/GradientVideoExportTypes.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 #if canImport(AVFoundation) && canImport(CoreImage) && (canImport(UIKit) || canImport(AppKit))
 import AVFoundation
-import CoreImage
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -103,6 +102,19 @@ public extension MeshingKit {
         let viewSize: CGSize
         let outputSize: CGSize
         let snapshot: VideoExportSnapshot
+        let precomputedAnimatedPositions: [[SIMD2<Float>]]?
+
+        func points(forFrame frameIndex: Int) -> [SIMD2<Float>] {
+            if let precomputedAnimatedPositions {
+                return precomputedAnimatedPositions[frameIndex]
+            }
+            let phase = Double(frameIndex) * timePerFrame
+            return MeshingKit.animatedPositions(
+                for: phase,
+                positions: snapshot.positions,
+                animate: snapshot.shouldAnimate
+            )
+        }
     }
 
     static func makeLoopConfig(config: VideoExportConfig) -> FrameLoopConfig {
@@ -111,13 +123,29 @@ public extension MeshingKit {
             Int((config.duration * Double(config.frameRate)).rounded(.toNearestOrAwayFromZero))
         )
         let timePerFrame = 1.0 / Double(config.frameRate)
+        let shouldPrecompute = config.snapshot.shouldAnimate
+            && totalFrames <= maxPrecomputedAnimationFrames
+
+        let precomputedAnimatedPositions: [[SIMD2<Float>]]? = if shouldPrecompute {
+            (0..<totalFrames).map { frameIndex in
+                let phase = Double(frameIndex) * timePerFrame
+                return MeshingKit.animatedPositions(
+                    for: phase,
+                    positions: config.snapshot.positions,
+                    animate: true
+                )
+            }
+        } else {
+            nil
+        }
 
         return FrameLoopConfig(
             totalFrames: totalFrames,
             timePerFrame: timePerFrame,
             viewSize: config.viewSize,
             outputSize: config.outputSize,
-            snapshot: config.snapshot
+            snapshot: config.snapshot,
+            precomputedAnimatedPositions: precomputedAnimatedPositions
         )
     }
 
@@ -130,15 +158,15 @@ public extension MeshingKit {
         )
 
         let frameDuration = CMTimeMake(value: 1, timescale: config.frameRate)
-        let context = CIContext(options: [.useSoftwareRenderer: false])
         let state = VideoWriterState()
 
         return FrameLoopDriver(
             assetConfig: assetConfig,
-            context: context,
             frameDuration: frameDuration,
             state: state
         )
     }
+
+    private static let maxPrecomputedAnimationFrames = 12_000
 }
 #endif

--- a/Sources/MeshingKit/PredefinedTemplate.swift
+++ b/Sources/MeshingKit/PredefinedTemplate.swift
@@ -116,27 +116,27 @@ public extension PredefinedTemplate {
     }
 
     /// The palette colors for the template.
-    package var palette: [Color] {
+    var palette: [Color] {
         template.colors
     }
 
     /// The background color for the template.
-    package var background: Color {
+    var background: Color {
         template.background
     }
 
     /// Tags derived from the template name and mood.
-    package var tags: [String] {
+    var tags: [String] {
         metadataValue.tags
     }
 
     /// Moods derived from the template name.
-    package var moods: [TemplateMood] {
+    var moods: [TemplateMood] {
         metadataValue.moods
     }
 
     /// Combined metadata for the template.
-    package var metadata: TemplateMetadata {
+    var metadata: TemplateMetadata {
         metadataValue
     }
 
@@ -166,6 +166,7 @@ public extension PredefinedTemplate {
         .map { $0.template }
 
         if let limit {
+            guard limit >= 0 else { return [] }
             return Array(results.prefix(limit))
         }
         return results

--- a/Sources/MeshingKit/PredefinedTemplate.swift
+++ b/Sources/MeshingKit/PredefinedTemplate.swift
@@ -12,7 +12,7 @@ import NaturalLanguage
 #endif
 
 /// A type representing predefined gradient templates of different sizes.
-public enum PredefinedTemplate: Identifiable, CaseIterable, Equatable {
+public enum PredefinedTemplate: Identifiable, CaseIterable, Equatable, Sendable {
     case size2(GradientTemplateSize2)
     case size3(GradientTemplateSize3)
     case size4(GradientTemplateSize4)
@@ -87,18 +87,7 @@ public struct TemplateMetadata: Sendable {
 public extension PredefinedTemplate {
     /// Template metadata computed on demand.
     package var metadataValue: TemplateMetadata {
-        let nameTokens = Self.normalizedTokens(from: rawName)
-        let moodList = Self.moods(for: nameTokens)
-        let moodTokens = moodList.map(\.rawValue)
-        let tags = Self.uniqueTokens(nameTokens + moodTokens)
-
-        return TemplateMetadata(
-            name: template.name,
-            tags: tags,
-            moods: moodList,
-            palette: template.colors,
-            background: template.background
-        )
+        Self.metadataByID[id] ?? Self.makeMetadata(for: self)
     }
 
     /// The underlying template for this predefined case.
@@ -117,12 +106,12 @@ public extension PredefinedTemplate {
 
     /// The palette colors for the template.
     var palette: [Color] {
-        template.colors
+        metadataValue.palette
     }
 
     /// The background color for the template.
     var background: Color {
-        template.background
+        metadataValue.background
     }
 
     /// Tags derived from the template name and mood.
@@ -152,10 +141,9 @@ public extension PredefinedTemplate {
             return allCases
         }
 
-        let results = allCases.compactMap { template -> (score: Int, template: PredefinedTemplate)? in
-            let tokens = template.searchTokens
-            let score = matchScore(for: queryTokens, in: tokens)
-            return score > 0 ? (score, template) : nil
+        let results = searchIndex.compactMap { entry -> (score: Int, template: PredefinedTemplate)? in
+            let score = matchScore(for: queryTokens, in: entry.tokens)
+            return score > 0 ? (score, entry.template) : nil
         }
         .sorted { lhs, rhs in
             if lhs.score == rhs.score {
@@ -174,6 +162,11 @@ public extension PredefinedTemplate {
 }
 
 private extension PredefinedTemplate {
+    struct SearchIndexEntry: Sendable {
+        let template: PredefinedTemplate
+        let tokens: [String]
+    }
+
     var rawName: String {
         switch self {
         case .size2(let specificTemplate): return specificTemplate.rawValue
@@ -182,9 +175,43 @@ private extension PredefinedTemplate {
         }
     }
 
-    var searchTokens: [String] {
-        tags
+    static func makeMetadata(for template: PredefinedTemplate) -> TemplateMetadata {
+        let nameTokens = normalizedTokens(from: template.rawName)
+        let moodList = moods(for: nameTokens)
+        let moodTokens = moodList.map(\.rawValue)
+        let tags = uniqueTokens(nameTokens + moodTokens)
+
+        return TemplateMetadata(
+            name: template.template.name,
+            tags: tags,
+            moods: moodList,
+            palette: template.template.colors,
+            background: template.template.background
+        )
     }
+
+    static let indexedTemplates: [(template: PredefinedTemplate, metadata: TemplateMetadata)] = {
+        allCases.map { template in
+            (template: template, metadata: makeMetadata(for: template))
+        }
+    }()
+
+    static let metadataByID: [String: TemplateMetadata] = {
+        Dictionary(
+            uniqueKeysWithValues: indexedTemplates.map { entry in
+                (entry.template.id, entry.metadata)
+            }
+        )
+    }()
+
+    static let searchIndex: [SearchIndexEntry] = {
+        indexedTemplates.map { entry in
+            SearchIndexEntry(
+                template: entry.template,
+                tokens: entry.metadata.tags
+            )
+        }
+    }()
 
     static func moods(for tokens: [String]) -> [TemplateMood] {
         var matched: [TemplateMood] = []

--- a/Tests/MeshingKitTests/ExportTests.swift
+++ b/Tests/MeshingKitTests/ExportTests.swift
@@ -71,6 +71,28 @@ struct ExportTests {
         }
     }
 
+    @Test("Video export rejects invalid timeout")
+    func exportVideoRejectsInvalidTimeout() async {
+        do {
+            _ = try await MeshingKit.exportVideo(
+                template: .size2(.mysticTwilight),
+                size: CGSize(width: 320, height: 320),
+                duration: 1,
+                frameRate: 2,
+                timeout: .infinity
+            )
+            #expect(Bool(false), "Expected exportVideo to throw for invalid timeout.")
+        } catch let error as VideoExportError {
+            if case .invalidConfiguration(let message) = error {
+                #expect(message.contains("Timeout"))
+            } else {
+                #expect(Bool(false), "Unexpected error: \(error)")
+            }
+        } catch {
+            #expect(Bool(false), "Unexpected error type: \(error)")
+        }
+    }
+
 #if canImport(AVFoundation) && canImport(CoreImage) && (canImport(UIKit) || canImport(AppKit))
     @Test("Video export writes a file")
     func exportVideoWritesFile() async throws {

--- a/Tests/MeshingKitTests/ExportTests.swift
+++ b/Tests/MeshingKitTests/ExportTests.swift
@@ -117,6 +117,53 @@ struct ExportTests {
             try? FileManager.default.removeItem(at: url)
         }
     }
+
+    @Test("Video export preserves orientation for static frame")
+    @MainActor
+    func exportVideoPreservesOrientation() async throws {
+        let size = CGSize(width: 180, height: 180)
+        let margin = 20
+
+        guard let snapshot = MeshingKit.snapshotCGImage(
+            template: .size2(.tropicalParadise),
+            size: size,
+            scale: 1,
+            smoothsColors: true
+        ) else {
+            #expect(Bool(false), "Expected snapshotCGImage to succeed.")
+            return
+        }
+
+        let url = try await MeshingKit.exportVideo(
+            template: .size2(.tropicalParadise),
+            size: size,
+            duration: 1.0,
+            frameRate: 1,
+            animate: false,
+            smoothsColors: true,
+            renderScale: 1
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
+        generator.appliesPreferredTrackTransform = true
+        let frame = try generator.copyCGImage(at: .zero, actualTime: nil)
+
+        let snapTL = sampleRGB(snapshot, x: margin, y: margin)
+        let snapTR = sampleRGB(snapshot, x: snapshot.width - margin - 1, y: margin)
+        let snapBL = sampleRGB(snapshot, x: margin, y: snapshot.height - margin - 1)
+        let snapBR = sampleRGB(snapshot, x: snapshot.width - margin - 1, y: snapshot.height - margin - 1)
+
+        let videoTL = sampleRGB(frame, x: margin, y: margin)
+        let videoTR = sampleRGB(frame, x: frame.width - margin - 1, y: margin)
+        let videoBL = sampleRGB(frame, x: margin, y: frame.height - margin - 1)
+        let videoBR = sampleRGB(frame, x: frame.width - margin - 1, y: frame.height - margin - 1)
+
+        #expect(colorDistance(snapTL, videoTL) < colorDistance(snapTL, videoBL))
+        #expect(colorDistance(snapTR, videoTR) < colorDistance(snapTR, videoBR))
+        #expect(colorDistance(snapBL, videoBL) < colorDistance(snapBL, videoTL))
+        #expect(colorDistance(snapBR, videoBR) < colorDistance(snapBR, videoTR))
+    }
 #endif
 }
 
@@ -124,4 +171,46 @@ private func isApproximatelyEqual(_ lhs: Double, _ rhs: Double, tolerance: Doubl
     -> Bool
 {
     abs(lhs - rhs) <= tolerance
+}
+
+private func sampleRGB(_ image: CGImage, x: Int, y: Int) -> (r: Int, g: Int, b: Int) {
+    let clampedX = max(0, min(image.width - 1, x))
+    let clampedY = max(0, min(image.height - 1, y))
+
+    let bytesPerPixel = 4
+    let bytesPerRow = bytesPerPixel * image.width
+    var data = [UInt8](repeating: 0, count: bytesPerRow * image.height)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+    data.withUnsafeMutableBytes { rawBuffer in
+        guard let baseAddress = rawBuffer.baseAddress else { return }
+        guard let context = CGContext(
+            data: baseAddress,
+            width: image.width,
+            height: image.height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            return
+        }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+    }
+
+    let offset = (clampedY * bytesPerRow) + (clampedX * bytesPerPixel)
+    return (
+        r: Int(data[offset]),
+        g: Int(data[offset + 1]),
+        b: Int(data[offset + 2])
+    )
+}
+
+private func colorDistance(_ lhs: (r: Int, g: Int, b: Int), _ rhs: (r: Int, g: Int, b: Int)) -> Int {
+    let dr = lhs.r - rhs.r
+    let dg = lhs.g - rhs.g
+    let db = lhs.b - rhs.b
+    return dr * dr + dg * dg + db * db
 }

--- a/Tests/MeshingKitTests/MeshingKitTests.swift
+++ b/Tests/MeshingKitTests/MeshingKitTests.swift
@@ -41,9 +41,9 @@ struct MeshingKitTests {
         let size3Count = GradientTemplateSize3.allCases.count
         let size4Count = GradientTemplateSize4.allCases.count
 
-        #expect(size2Count == 35)
-        #expect(size3Count == 22)
-        #expect(size4Count == 11)
+        #expect(size2Count == TemplateCatalogLock.size2Count)
+        #expect(size3Count == TemplateCatalogLock.size3Count)
+        #expect(size4Count == TemplateCatalogLock.size4Count)
 
         // Verify PredefinedTemplate.allCases matches the sum
         #expect(PredefinedTemplate.allCases.count == size2Count + size3Count + size4Count)
@@ -80,7 +80,9 @@ struct MeshingKitTests {
         let invalidColors = [
             "not-a-hex",
             "#GGGGGG",
-            "#12345"
+            "#12345",
+            "#FF0000ZZ",
+            "#80FF0000extra"
         ]
 
         for hexValue in invalidColors {
@@ -142,7 +144,7 @@ struct MeshingKitTests {
         let allTemplates = PredefinedTemplate.allCases
 
         // Verify count
-        #expect(allTemplates.count == 68)
+        #expect(allTemplates.count == TemplateCatalogLock.totalCount)
 
         // Verify all IDs are unique
         let ids = allTemplates.map { $0.id }
@@ -158,10 +160,17 @@ struct MeshingKitTests {
             }
         }
 
-        #expect(counts.size2 == 35)
-        #expect(counts.size3 == 22)
-        #expect(counts.size4 == 11)
+        #expect(counts.size2 == TemplateCatalogLock.size2Count)
+        #expect(counts.size3 == TemplateCatalogLock.size3Count)
+        #expect(counts.size4 == TemplateCatalogLock.size4Count)
     }
+}
+
+private enum TemplateCatalogLock {
+    static let size2Count = 35
+    static let size3Count = 22
+    static let size4Count = 11
+    static let totalCount = size2Count + size3Count + size4Count
 }
 
 private struct RGBA {

--- a/Tests/MeshingKitTests/PredefinedTemplateTests.swift
+++ b/Tests/MeshingKitTests/PredefinedTemplateTests.swift
@@ -42,6 +42,12 @@ struct PredefinedTemplateTests {
         #expect(results.count == 1)
     }
 
+    @Test("PredefinedTemplate find handles negative limit")
+    func predefinedTemplateFindNegativeLimit() {
+        let results = PredefinedTemplate.find(by: "aurora", limit: -1)
+        #expect(results.isEmpty)
+    }
+
     @Test("PredefinedTemplate find returns all for empty query")
     func predefinedTemplateFindEmptyQuery() {
         let results = PredefinedTemplate.find(by: "   ")

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -13,6 +13,13 @@ workflows:
       vars:
         XCODE_SCHEME: "MeshingKit"
         APP_ID: "MeshingKit"
+    cache:
+      cache_paths:
+        - ~/.swiftpm
+        - ~/Library/Caches/org.swift.swiftpm
+        - ~/Library/Caches/Homebrew
+        - /opt/homebrew/Cellar/swiftlint
+        - /usr/local/Cellar/swiftlint
     when:
       changeset:
         includes:
@@ -37,11 +44,12 @@ workflows:
           # Install swiftlint if not available
           if ! command -v swiftlint &> /dev/null; then
             echo "Installing SwiftLint..."
+            export HOMEBREW_NO_AUTO_UPDATE=1
             brew install swiftlint
           fi
 
           # Run swiftlint with strict mode
-          swiftlint --strict
+          swiftlint --strict --quiet
 
       - name: Build Swift Package
         script: |
@@ -58,11 +66,8 @@ workflows:
 
           echo "Testing MeshingKit..."
 
-          # Run tests with verbose output
-          swift test --verbose
-
-          # Generate code coverage report
-          swift test --enable-code-coverage
+          # Run tests once with coverage enabled.
+          swift test --enable-code-coverage --parallel
 
       - name: Build with Xcode (Multi-Platform)
         script: |
@@ -76,7 +81,7 @@ workflows:
           for DESTINATION in "${DESTINATIONS[@]}"
             do
               echo "Building for destination: $DESTINATION"
-              xcodebuild clean build \
+              xcodebuild build \
                 -project Sources/Meshin/Meshin.xcodeproj \
                 -scheme Meshin \
                 -destination "$DESTINATION" \


### PR DESCRIPTION
## Summary
- harden video export timeout handling and reject invalid timeout values instead of trapping
- make cancellation and continuation handling race-safe in the AVAssetWriter frame loop
- fix `PredefinedTemplate.find(by:limit:)` for negative limits (returns empty results)
- make `Color(hex:)` public and switch to strict full-string hex validation
- expose `PredefinedTemplate` metadata accessors (`palette`, `background`, `tags`, `moods`, `metadata`) for README parity
- render control-point dots when `showDots` is enabled for image and video exports
- clear stale success and error messages at the start of each Meshin export action
- add regression tests for invalid timeout, negative limits, and malformed hex input

## Validation
- `swift test` (27 tests passing)
