### PR TITLE
Fixed exports for custom animation patterns

### DIFF
--- a/Sources/MeshingKit/GradientExport+iOS.swift
+++ b/Sources/MeshingKit/GradientExport+iOS.swift
@@ -137,6 +137,7 @@ public extension MeshingKit {
     ///   - showDots: Whether to show dots (default: false).
     ///   - animate: Whether to animate (default: true).
     ///   - smoothsColors: Whether to smooth colors (default: true).
+    ///   - animationPattern: Optional custom animation pattern to apply during export (default: nil).
     ///   - completion: Called with the result. Temporary files are cleaned up automatically.
     public static func exportVideoToPhotoLibrary(
         template: any GradientTemplate,
@@ -148,6 +149,7 @@ public extension MeshingKit {
         animate: Bool = true,
         smoothsColors: Bool = true,
         renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil,
         completion: @escaping @Sendable (Result<Void, Error>) -> Void
     ) {
         Task {
@@ -161,7 +163,8 @@ public extension MeshingKit {
                     showDots: showDots,
                     animate: animate,
                     smoothsColors: smoothsColors,
-                    renderScale: renderScale
+                    renderScale: renderScale,
+                    animationPattern: animationPattern
                 )
 
                 do {
@@ -207,6 +210,7 @@ public extension MeshingKit {
             animate: configuration.animate,
             smoothsColors: configuration.smoothsColors,
             renderScale: configuration.renderScale,
+            animationPattern: configuration.animationPattern,
             completion: completion
         )
     }
@@ -224,6 +228,7 @@ public extension MeshingKit {
         animate: Bool = true,
         smoothsColors: Bool = true,
         renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil,
         completion: @escaping @Sendable (Result<Void, Error>) -> Void
     ) {
         exportVideoToPhotoLibrary(
@@ -236,6 +241,7 @@ public extension MeshingKit {
             animate: animate,
             smoothsColors: smoothsColors,
             renderScale: renderScale,
+            animationPattern: animationPattern,
             completion: completion
         )
     }

--- a/Sources/MeshingKit/GradientExport+macOS.swift
+++ b/Sources/MeshingKit/GradientExport+macOS.swift
@@ -221,6 +221,7 @@ public extension MeshingKit {
     ///   - animate: Whether to animate (default: true).
     ///   - smoothsColors: Whether to smooth colors (default: true).
     ///   - renderScale: Render scale multiplier (default: 1.0).
+    ///   - animationPattern: Optional custom animation pattern to apply during export (default: nil).
     ///   - fileName: The default file name (default: "mesh-gradient").
     ///   - timeout: Maximum time allowed for export (default: 30 minutes).
     ///   - completion: Called with the result URL or error.
@@ -235,6 +236,7 @@ public extension MeshingKit {
         animate: Bool = true,
         smoothsColors: Bool = true,
         renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil,
         fileName: String = "mesh-gradient",
         timeout: TimeInterval = videoExportTimeout,
         completion: @escaping (Result<URL, Error>) -> Void
@@ -271,6 +273,7 @@ public extension MeshingKit {
                         animate: animate,
                         smoothsColors: smoothsColors,
                         renderScale: renderScale,
+                        animationPattern: animationPattern,
                         timeout: timeout
                     )
 
@@ -303,6 +306,7 @@ public extension MeshingKit {
         animate: Bool = true,
         smoothsColors: Bool = true,
         renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil,
         fileName: String = "mesh-gradient",
         timeout: TimeInterval = videoExportTimeout,
         completion: @escaping (Result<URL, Error>) -> Void
@@ -317,6 +321,7 @@ public extension MeshingKit {
             animate: animate,
             smoothsColors: smoothsColors,
             renderScale: renderScale,
+            animationPattern: animationPattern,
             fileName: fileName,
             timeout: timeout,
             completion: completion
@@ -342,6 +347,7 @@ public extension MeshingKit {
             animate: configuration.animate,
             smoothsColors: configuration.smoothsColors,
             renderScale: configuration.renderScale,
+            animationPattern: configuration.animationPattern,
             fileName: fileName,
             timeout: timeout,
             completion: completion

--- a/Sources/MeshingKit/GradientVideoExport.swift
+++ b/Sources/MeshingKit/GradientVideoExport.swift
@@ -27,6 +27,7 @@ public struct VideoExportSnapshot: Sendable {
     public let showDots: Bool
     public let shouldAnimate: Bool
     public let renderScale: CGFloat
+    public let animationPattern: AnimationPattern?
 
     public init(
         gridSize: Int,
@@ -37,7 +38,8 @@ public struct VideoExportSnapshot: Sendable {
         blurRadius: CGFloat,
         showDots: Bool,
         shouldAnimate: Bool,
-        renderScale: CGFloat
+        renderScale: CGFloat,
+        animationPattern: AnimationPattern? = nil
     ) {
         self.gridSize = gridSize
         self.positions = positions
@@ -48,6 +50,7 @@ public struct VideoExportSnapshot: Sendable {
         self.showDots = showDots
         self.shouldAnimate = shouldAnimate
         self.renderScale = renderScale
+        self.animationPattern = animationPattern
     }
 }
 
@@ -61,6 +64,7 @@ public struct VideoExportConfiguration: Sendable {
     public var animate: Bool
     public var smoothsColors: Bool
     public var renderScale: CGFloat
+    public var animationPattern: AnimationPattern?
 
     public init(
         size: CGSize,
@@ -70,7 +74,8 @@ public struct VideoExportConfiguration: Sendable {
         showDots: Bool = false,
         animate: Bool = true,
         smoothsColors: Bool = true,
-        renderScale: CGFloat = 1.0
+        renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil
     ) {
         self.size = size
         self.duration = duration
@@ -80,6 +85,7 @@ public struct VideoExportConfiguration: Sendable {
         self.animate = animate
         self.smoothsColors = smoothsColors
         self.renderScale = renderScale
+        self.animationPattern = animationPattern
     }
 }
 
@@ -106,6 +112,7 @@ public extension MeshingKit {
             animate: configuration.animate,
             smoothsColors: configuration.smoothsColors,
             renderScale: configuration.renderScale,
+            animationPattern: configuration.animationPattern,
             timeout: timeout
         )
     }
@@ -122,6 +129,7 @@ public extension MeshingKit {
         animate: Bool = true,
         smoothsColors: Bool = true,
         renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil,
         timeout: TimeInterval = videoExportTimeout
     ) async throws -> URL {
         try validateVideoExportConfiguration(
@@ -141,7 +149,8 @@ public extension MeshingKit {
             showDots: showDots,
             animate: animate,
             smoothsColors: smoothsColors,
-            renderScale: renderScale
+            renderScale: renderScale,
+            animationPattern: animationPattern
         )
 
         let params = buildExportParams(template: template, size: size, config: config, timeout: timeout)
@@ -190,7 +199,8 @@ public extension MeshingKit {
             blurRadius: config.blurRadius,
             showDots: config.showDots,
             shouldAnimate: config.animate,
-            renderScale: config.renderScale
+            renderScale: config.renderScale,
+            animationPattern: config.animationPattern
         )
 
         return VideoExportParams(
@@ -271,6 +281,7 @@ public extension MeshingKit {
         animate: Bool = true,
         smoothsColors: Bool = true,
         renderScale: CGFloat = 1.0,
+        animationPattern: AnimationPattern? = nil,
         timeout: TimeInterval = videoExportTimeout
     ) async throws -> URL {
         try await exportVideo(
@@ -283,6 +294,7 @@ public extension MeshingKit {
             animate: animate,
             smoothsColors: smoothsColors,
             renderScale: renderScale,
+            animationPattern: animationPattern,
             timeout: timeout
         )
     }

--- a/Sources/MeshingKit/GradientVideoExportTypes.swift
+++ b/Sources/MeshingKit/GradientVideoExportTypes.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import simd
 
 #if canImport(AVFoundation) && canImport(CoreImage) && (canImport(UIKit) || canImport(AppKit))
 import AVFoundation
@@ -103,12 +104,17 @@ public extension MeshingKit {
         let outputSize: CGSize
         let snapshot: VideoExportSnapshot
         let precomputedAnimatedPositions: [[SIMD2<Float>]]?
+        let animationPattern: AnimationPattern?
 
         func points(forFrame frameIndex: Int) -> [SIMD2<Float>] {
             if let precomputedAnimatedPositions {
                 return precomputedAnimatedPositions[frameIndex]
             }
             let phase = Double(frameIndex) * timePerFrame
+            if let pattern = animationPattern {
+                let animated = pattern.apply(to: snapshot.positions, at: phase)
+                return animated.map { simd_clamp($0, .zero, SIMD2<Float>(repeating: 1)) }
+            }
             return MeshingKit.animatedPositions(
                 for: phase,
                 positions: snapshot.positions,
@@ -125,10 +131,15 @@ public extension MeshingKit {
         let timePerFrame = 1.0 / Double(config.frameRate)
         let shouldPrecompute = config.snapshot.shouldAnimate
             && totalFrames <= maxPrecomputedAnimationFrames
+        let pattern = config.snapshot.animationPattern
 
         let precomputedAnimatedPositions: [[SIMD2<Float>]]? = if shouldPrecompute {
             (0..<totalFrames).map { frameIndex in
                 let phase = Double(frameIndex) * timePerFrame
+                if let pattern {
+                    let animated = pattern.apply(to: config.snapshot.positions, at: phase)
+                    return animated.map { simd_clamp($0, .zero, SIMD2<Float>(repeating: 1)) }
+                }
                 return MeshingKit.animatedPositions(
                     for: phase,
                     positions: config.snapshot.positions,
@@ -145,7 +156,8 @@ public extension MeshingKit {
             viewSize: config.viewSize,
             outputSize: config.outputSize,
             snapshot: config.snapshot,
-            precomputedAnimatedPositions: precomputedAnimatedPositions
+            precomputedAnimatedPositions: precomputedAnimatedPositions,
+            animationPattern: pattern
         )
     }
 

--- a/Sources/MeshingKit/GradientVideoExportTypes.swift
+++ b/Sources/MeshingKit/GradientVideoExportTypes.swift
@@ -131,7 +131,7 @@ public extension MeshingKit {
         let timePerFrame = 1.0 / Double(config.frameRate)
         let shouldPrecompute = config.snapshot.shouldAnimate
             && totalFrames <= maxPrecomputedAnimationFrames
-        let pattern = config.snapshot.animationPattern
+        let pattern = config.snapshot.shouldAnimate ? config.snapshot.animationPattern : nil
 
         let precomputedAnimatedPositions: [[SIMD2<Float>]]? = if shouldPrecompute {
             (0..<totalFrames).map { frameIndex in

--- a/Tests/MeshingKitTests/ExportTests.swift
+++ b/Tests/MeshingKitTests/ExportTests.swift
@@ -143,8 +143,8 @@ struct ExportTests {
         let generator2 = AVAssetImageGenerator(asset: AVURLAsset(url: urlCustom))
         generator2.appliesPreferredTrackTransform = true
 
-        let frameDefault = try generator1.copyCGImage(at: .zero, actualTime: nil)
-        let frameCustom = try generator2.copyCGImage(at: .zero, actualTime: nil)
+        let frameDefault = try await image(at: .zero, generator: generator1)
+        let frameCustom = try await image(at: .zero, generator: generator2)
 
         let centerDefault = sampleRGB(frameDefault, x: 100, y: 100)
         let centerCustom = sampleRGB(frameCustom, x: 100, y: 100)
@@ -152,6 +152,48 @@ struct ExportTests {
         #expect(
             colorDistance(centerDefault, centerCustom) > 100,
             "Center pixel should differ between default and custom animation pattern exports"
+        )
+    }
+
+    @Test("Video export ignores custom animation pattern when animate is false")
+    func exportVideoIgnoresCustomAnimationPatternWhenAnimationDisabled() async throws {
+        let template = GradientTemplateSize3.auroraBorealis
+        let size = CGSize(width: 200, height: 200)
+
+        let pattern = AnimationPattern(animations: [
+            PointAnimation(pointIndex: 4, axis: .both, amplitude: 0.45, frequency: 0.0)
+        ])
+
+        let urlStatic = try await MeshingKit.exportVideo(
+            template: template, size: size, duration: 1, frameRate: 1, animate: false
+        )
+        let urlStaticWithPattern = try await MeshingKit.exportVideo(
+            template: template,
+            size: size,
+            duration: 1,
+            frameRate: 1,
+            animate: false,
+            animationPattern: pattern
+        )
+        defer {
+            try? FileManager.default.removeItem(at: urlStatic)
+            try? FileManager.default.removeItem(at: urlStaticWithPattern)
+        }
+
+        let generator1 = AVAssetImageGenerator(asset: AVURLAsset(url: urlStatic))
+        generator1.appliesPreferredTrackTransform = true
+        let generator2 = AVAssetImageGenerator(asset: AVURLAsset(url: urlStaticWithPattern))
+        generator2.appliesPreferredTrackTransform = true
+
+        let frameStatic = try await image(at: .zero, generator: generator1)
+        let frameStaticWithPattern = try await image(at: .zero, generator: generator2)
+
+        let centerStatic = sampleRGB(frameStatic, x: 100, y: 100)
+        let centerStaticWithPattern = sampleRGB(frameStaticWithPattern, x: 100, y: 100)
+
+        #expect(
+            colorDistance(centerStatic, centerStaticWithPattern) == 0,
+            "Custom animation patterns should be ignored when animate is false"
         )
     }
 
@@ -184,7 +226,7 @@ struct ExportTests {
 
         let generator = AVAssetImageGenerator(asset: AVURLAsset(url: url))
         generator.appliesPreferredTrackTransform = true
-        let frame = try generator.copyCGImage(at: .zero, actualTime: nil)
+        let frame = try await image(at: .zero, generator: generator)
 
         let snapTL = sampleRGB(snapshot, x: margin, y: margin)
         let snapTR = sampleRGB(snapshot, x: snapshot.width - margin - 1, y: margin)
@@ -208,6 +250,11 @@ private func isApproximatelyEqual(_ lhs: Double, _ rhs: Double, tolerance: Doubl
     -> Bool
 {
     abs(lhs - rhs) <= tolerance
+}
+
+private func image(at time: CMTime, generator: AVAssetImageGenerator) async throws -> CGImage {
+    let frame = try await generator.image(at: time)
+    return frame.image
 }
 
 private func sampleRGB(_ image: CGImage, x: Int, y: Int) -> (r: Int, g: Int, b: Int) {

--- a/Tests/MeshingKitTests/ExportTests.swift
+++ b/Tests/MeshingKitTests/ExportTests.swift
@@ -118,6 +118,43 @@ struct ExportTests {
         }
     }
 
+    @Test("Video export uses custom animation pattern")
+    func exportVideoUsesCustomAnimationPattern() async throws {
+        let template = GradientTemplateSize3.auroraBorealis
+        let size = CGSize(width: 200, height: 200)
+
+        let pattern = AnimationPattern(animations: [
+            PointAnimation(pointIndex: 4, axis: .both, amplitude: 0.45, frequency: 0.0)
+        ])
+
+        let urlDefault = try await MeshingKit.exportVideo(
+            template: template, size: size, duration: 1, frameRate: 1
+        )
+        let urlCustom = try await MeshingKit.exportVideo(
+            template: template, size: size, duration: 1, frameRate: 1, animationPattern: pattern
+        )
+        defer {
+            try? FileManager.default.removeItem(at: urlDefault)
+            try? FileManager.default.removeItem(at: urlCustom)
+        }
+
+        let generator1 = AVAssetImageGenerator(asset: AVURLAsset(url: urlDefault))
+        generator1.appliesPreferredTrackTransform = true
+        let generator2 = AVAssetImageGenerator(asset: AVURLAsset(url: urlCustom))
+        generator2.appliesPreferredTrackTransform = true
+
+        let frameDefault = try generator1.copyCGImage(at: .zero, actualTime: nil)
+        let frameCustom = try generator2.copyCGImage(at: .zero, actualTime: nil)
+
+        let centerDefault = sampleRGB(frameDefault, x: 100, y: 100)
+        let centerCustom = sampleRGB(frameCustom, x: 100, y: 100)
+
+        #expect(
+            colorDistance(centerDefault, centerCustom) > 100,
+            "Center pixel should differ between default and custom animation pattern exports"
+        )
+    }
+
     @Test("Video export preserves orientation for static frame")
     @MainActor
     func exportVideoPreservesOrientation() async throws {


### PR DESCRIPTION
## fix: thread AnimationPattern through video export pipeline

Custom `AnimationPattern` passed to `animatedGradient` was silently ignored during video export. The export pipeline had no slot for the pattern at any layer, so all exported videos fell back to the hardcoded default animation regardless of what the live view was showing.

## Changes

- Added `animationPattern: AnimationPattern?` to `VideoExportSnapshot` and `VideoExportConfiguration`
- Threaded the parameter through `exportVideo`, `exportVideoToPhotoLibrary` (iOS), and `exportVideoToDisk` (macOS) — all defaulting to `nil` for full backward compatibility
- Updated `FrameLoopConfig.points(forFrame:)` and `makeLoopConfig` to use `pattern.apply()` when a pattern is present, falling back to the existing hardcoded math when `nil`
- Added a test that exports the same template twice (with and without a custom pattern) and asserts the resulting video frames differ

## Testing

Run the new test directly:

​```bash
swift test --filter "exportVideoUsesCustomAnimationPattern"
​```